### PR TITLE
Enhancement of Javadocs command to include Java 8 Javadocs

### DIFF
--- a/src/main/java/com/kantenkugel/discordbot/jdocparser/Documentation.java
+++ b/src/main/java/com/kantenkugel/discordbot/jdocparser/Documentation.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public interface Documentation {
     String getTitle();
-    String getUrl();
+    String getUrl(String jdocBase);
     String getContent();
     default Map<String, List<String>> getFields() {return null;}
 }

--- a/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocUtil.java
+++ b/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocUtil.java
@@ -65,7 +65,20 @@ public class JDocUtil {
         }
         matcher.appendTail(sb);
         docs = sb.toString();
-        docs = CODE_PATTERN.matcher(docs).replaceAll("`$1`");
+        sb = new StringBuffer();
+        matcher = CODE_PATTERN.matcher(docs);
+        while(matcher.find()) {
+            StringBuffer sb2 = new StringBuffer("`");
+            Matcher codeLinkMatcher = LINK_PATTERN.matcher(matcher.group(1));
+            while(codeLinkMatcher.find()) {
+                codeLinkMatcher.appendReplacement(sb2, codeLinkMatcher.group(4));
+            }
+            codeLinkMatcher.appendTail(sb2);
+            sb2.append('`');
+            matcher.appendReplacement(sb, sb2.toString().replace("$", "\\$"));
+        }
+        matcher.appendTail(sb);
+        docs = sb.toString();
 
         //links
         matcher = LINK_PATTERN.matcher(docs);

--- a/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocUtil.java
+++ b/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocUtil.java
@@ -32,6 +32,9 @@ public class JDocUtil {
 
     static final Path LOCAL_DOC_PATH = Paths.get("jda-docs.jar");
 
+    public static final String JAVA_JDOCS_PREFIX = "https://docs.oracle.com/javase/8/docs/api/";
+    static final String JAVA_JDOCS_CLASS_INDEX = JAVA_JDOCS_PREFIX + "allclasses-noframe.html";
+
     public static final String JDOCBASE = JenkinsApi.LAST_BUILD_URL + "javadoc/";
 
     static final String JDA_CODE_BASE = "net/dv8tion/jda";
@@ -99,12 +102,12 @@ public class JDocUtil {
         return input == null ? null : input.replaceAll("\\h", " ");
     }
 
-    static String getLink(JDocParser.ClassDocumentation doc) {
-        return getLink(doc.pack, doc.className);
+    static String getLink(String jdocBase, JDocParser.ClassDocumentation doc) {
+        return getLink(jdocBase, doc.pack, doc.className);
     }
 
-    static String getLink(String classPackage, String className) {
-        return JDOCBASE + classPackage.replace(".", "/") + '/' + className + ".html";
+    static String getLink(String jdocBase, String classPackage, String className) {
+        return jdocBase + classPackage.replace(".", "/") + '/' + className + ".html";
     }
 
     static String resolveLink(String href, String relativeTo) {

--- a/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocUtil.java
+++ b/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocUtil.java
@@ -86,6 +86,7 @@ public class JDocUtil {
         //cut remaining html tags
         docs = docs.replaceAll("<[^>]+>", "");
         docs = docs.replace("&lt;", "<").replace("&gt;", ">");
+        docs = docs.replace("&nbsp;", " ");
 
         //space and newline trimming cleanup
         docs = docs.replaceAll("[ ]{2,}", " ");

--- a/src/test/java/JDocParserTest.java
+++ b/src/test/java/JDocParserTest.java
@@ -1,6 +1,7 @@
 import com.almightyalpaca.discord.jdabutler.Bot;
 import com.kantenkugel.discordbot.jdocparser.Documentation;
 import com.kantenkugel.discordbot.jdocparser.JDoc;
+import com.kantenkugel.discordbot.jdocparser.JDocUtil;
 import okhttp3.OkHttpClient;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -82,7 +83,7 @@ public class JDocParserTest {
         assertEquals("Message should be found as single result", 1, message.size());
         assertEquals("URL of Message docs mismatches",
                 "http://home.dv8tion.net:8080/job/JDA/lastSuccessfulBuild/javadoc/net/dv8tion/jda/core/entities/Message.html",
-                message.get(0).getUrl()
+                message.get(0).getUrl(JDocUtil.JDOCBASE)
         );
     }
 }


### PR DESCRIPTION
Added possibility to get docs of standard Java 8 Javadocs.
- Fetches Index from <https://docs.oracle.com/javase/8/docs/api/allclasses-noframe.html>
- Stores name + link to all classes that are in the `java.*` packages
- On request, reads+parses online docs of wanted class instead of pre-parsing + caching all java 8 classes (around 2k in `java.*`)
- Improved JDocUtil. Now replaces html-escaped spaces and ignores links inside of \<code> blocks