### PR TITLE
Using VersionedItems for notify and announce commands.

### DIFF
--- a/src/main/java/com/almightyalpaca/discord/jdabutler/Bot.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/Bot.java
@@ -42,11 +42,6 @@ public class Bot
 
     public static final Logger LOG = (Logger) LoggerFactory.getLogger(Bot.class);
 
-    public static TextChannel getChannelExperimental()
-    {
-        return Bot.jda.getTextChannelById("289742061220134912");
-    }
-
     public static Guild getGuildJda()
     {
         return Bot.jda.getGuildById("125227483518861312");
@@ -55,16 +50,6 @@ public class Bot
     public static Role getRoleBots()
     {
         return Bot.getGuildJda().getRoleById("125616720156033024");
-    }
-
-    public static Role getRoleExperimentalUpdates()
-    {
-        return Bot.getGuildJda().getRoleById("289744006433472513");
-    }
-
-    public static Role getRoleHelper()
-    {
-        return Bot.getGuildJda().getRoleById("183963327033114624");
     }
 
     public static Role getRoleJdaFanclub()
@@ -94,11 +79,6 @@ public class Bot
     {
         final Member member = Bot.getGuildJda().getMember(user);
         return member != null && member.getRoles().contains(Bot.getRoleStaff());
-    }
-
-    public static boolean isHelper(final User sender)
-    {
-        return Bot.getGuildJda().isMember(sender) && (Bot.isAdmin(sender) || Bot.getGuildJda().getMember(sender).getRoles().contains(Bot.getRoleHelper()));
     }
 
     public static void main(final String[] args) throws JsonIOException, JsonSyntaxException, WrongTypeException, KeyNotFoundException, IOException, LoginException, IllegalArgumentException, InterruptedException, SecurityException

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/Bot.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/Bot.java
@@ -42,29 +42,9 @@ public class Bot
 
     public static final Logger LOG = (Logger) LoggerFactory.getLogger(Bot.class);
 
-    public static TextChannel getChannelAnnouncements()
-    {
-        return Bot.jda.getTextChannelById("125227483518861312");
-    }
-
     public static TextChannel getChannelExperimental()
     {
         return Bot.jda.getTextChannelById("289742061220134912");
-    }
-
-    public static TextChannel getChannelLavaplayer()
-    {
-        return Bot.jda.getTextChannelById("263484072389640193");
-    }
-
-    public static TextChannel getChannelLogs()
-    {
-        return Bot.jda.getTextChannelById("241926199666802690");
-    }
-
-    public static TextChannel getChannelTesting()
-    {
-        return Bot.jda.getTextChannelById("115567590495092740");
     }
 
     public static Guild getGuildJda()
@@ -90,16 +70,6 @@ public class Bot
     public static Role getRoleJdaFanclub()
     {
         return Bot.getGuildJda().getRoleById("169558668126322689");
-    }
-
-    public static Role getRoleJdaUpdates()
-    {
-        return Bot.getGuildJda().getRoleById("241948671325765632");
-    }
-
-    public static Role getRoleLavaplayerUpdates()
-    {
-        return Bot.getGuildJda().getRoleById("241948768113524762");
     }
 
     public static Role getRoleStaff()

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/AnnouncementCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/AnnouncementCommand.java
@@ -25,6 +25,12 @@ public class AnnouncementCommand implements Command
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
     {
+        if(!channel.getGuild().equals(Bot.getGuildJda()))
+        {
+            this.sendFailed(message);
+            return;
+        }
+
         final String[] args = content.split("\\s\\|\\s", 3);
 
         if (args.length < 2)

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
@@ -42,7 +42,7 @@ public class NotifyCommand implements Command
                     .distinct() //just in case 2 items use same announcement role
                     .collect(Collectors.toList());
             if(content.contains("experimental"))
-                roles.add(Bot.getRoleExperimentalUpdates());
+                roles.add(VersionCheckerRegistry.EXPERIMENTAL_ITEM.getAnnouncementRole());
         }
 
         if(roles.size() == 0)

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
@@ -2,17 +2,20 @@ package com.almightyalpaca.discord.jdabutler.commands.commands;
 
 import com.almightyalpaca.discord.jdabutler.Bot;
 import com.almightyalpaca.discord.jdabutler.commands.Command;
+import com.kantenkugel.discordbot.versioncheck.VersionCheckerRegistry;
+import com.kantenkugel.discordbot.versioncheck.items.VersionedItem;
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class NotifyCommand implements Command
 {
 
-    private static final String[] ALIASES = new String[]
-    { "subscribe" };
+    private static final String[] ALIASES = { "subscribe" };
 
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
@@ -26,68 +29,70 @@ public class NotifyCommand implements Command
             return;
         }
 
-        if (content.contains("all") || content.contains("both"))
+        final List<Role> roles;
+        if(content.trim().isEmpty())
         {
-            final List<Role> roles = new ArrayList<>(3);
-            roles.add(Bot.getRoleJdaUpdates());
-            roles.add(Bot.getRoleLavaplayerUpdates());
-            roles.removeAll(member.getRoles());
-
-            if (roles.size() == 0)
-            {
-                Role[] updateRoles = { Bot.getRoleJdaUpdates(), Bot.getRoleLavaplayerUpdates() };
-                guild.getController().removeRolesFromMember(member, updateRoles).queue(v ->
-                {
-                    logRoleRemoval(sender, Bot.getRoleJdaUpdates());
-                    logRoleRemoval(sender, Bot.getRoleLavaplayerUpdates());
-                }, e -> Bot.LOG.error("Could not remove role(s) from member {}", member.getUser().getName(), e));
-            }
-            else
-            {
-                guild.getController().addRolesToMember(member, roles)
-                        .queue(v -> roles.forEach( r -> logRoleAddition(sender, r)),
-                                e -> Bot.LOG.error("Could not add role(s) from member {}", member.getUser().getName(), e));
-            }
-
+            roles = Collections.singletonList(VersionCheckerRegistry.getItem("jda").getAnnouncementRole());
         }
         else
         {
-            final Role role;
-
-            if (content.contains("player"))
-                role = Bot.getRoleLavaplayerUpdates();
-            else if (content.contains("experimental"))
-                role = Bot.getRoleExperimentalUpdates();
-            else
-                role = Bot.getRoleJdaUpdates();
-
-            if (member.getRoles().contains(role))
-            {
-                guild.getController().removeSingleRoleFromMember(member, role)
-                        .queue(v -> logRoleRemoval(sender, role),
-                                e -> Bot.LOG.error("Could not remove role from member {}", member.getUser().getName(), e));
-            }
-            else
-            {
-                guild.getController().addSingleRoleToMember(member, role)
-                        .queue(v -> logRoleAddition(sender, role),
-                                e -> Bot.LOG.error("Could not add role from member {}", member.getUser().getName(), e));
-            }
+            roles = VersionCheckerRegistry.getItemsFromString(content, false).stream()
+                    .map(VersionedItem::getAnnouncementRole)
+                    .filter(Objects::nonNull)
+                    .distinct() //just in case 2 items use same announcement role
+                    .collect(Collectors.toList());
+            if(content.contains("experimental"))
+                roles.add(Bot.getRoleExperimentalUpdates());
         }
 
-        message.addReaction("\uD83D\uDC4C\uD83C\uDFFC").queue();
+        if(roles.size() == 0)
+        {
+            channel.sendMessage("No role(s) found for query").queue();
+            return;
+        }
+
+        List<Role> missingRoles = roles.stream().filter(r -> !member.getRoles().contains(r)).collect(Collectors.toList());
+        if(missingRoles.size() > 0)
+        {
+            guild.getController().addRolesToMember(member, missingRoles).reason("Notify command").queue(vd ->
+            {
+                logRoleAddition(sender, missingRoles);
+                channel.sendMessage("Added you to role(s) "+getRoleListString(missingRoles)).queue();
+            }, e ->
+            {
+                Bot.LOG.error("Could not add role(s) to user {}", sender.getIdLong(), e);
+                channel.sendMessage("There was an error adding roles. Please notify the devs.").queue();
+            });
+        }
+        else
+        {
+            guild.getController().removeRolesFromMember(member, roles).reason("Notify command").queue(vd ->
+            {
+                logRoleRemoval(sender, roles);
+                channel.sendMessage("Removed you from role(s) "+getRoleListString(roles)).queue();
+            }, e ->
+            {
+                Bot.LOG.error("Could not remove role(s) from user {}", sender.getIdLong(), e);
+                channel.sendMessage("There was an error removing roles. Please notify the devs.").queue();
+            });
+        }
     }
 
-    private void logRoleRemoval(final User sender, final Role role)
+    private static void logRoleRemoval(final User sender, final List<Role> roles)
     {
-        final String msg = String.format("Removed %#s (%d) from %s", sender, sender.getIdLong(), role.getName());
+        final String msg = String.format("Removed %#s (%d) from %s", sender, sender.getIdLong(), getRoleListString(roles));
         Bot.LOG.info(msg);
     }
 
-    private void logRoleAddition(final User sender, final Role role)
+    private static void logRoleAddition(final User sender, final List<Role> roles)
     {
-        final String msg = String.format("Added %#s (%d) to %s", sender, sender.getIdLong(), role.getName());
+        final String msg = String.format("Added %#s (%d) to %s", sender, sender.getIdLong(), getRoleListString(roles));
         Bot.LOG.info(msg);
+    }
+
+    private static String getRoleListString(List<Role> roles)
+    {
+        return roles.stream().map(Role::getName).collect(Collectors.joining(", "));
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
@@ -96,7 +96,7 @@ public class NotifyCommand implements Command
 
     private static String getRoleListString(List<Role> roles)
     {
-        return roles.stream().map(Role::getName).collect(Collectors.joining(", "));
+        return roles.stream().map(r -> '`' + r.getName() + '`').collect(Collectors.joining(", "));
     }
 
     @Override

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
@@ -98,12 +98,14 @@ public class VersionCheckerRegistry
         addItem(new SimpleVersionedItem("Lavaplayer", RepoType.JCENTER, DependencyType.DEFAULT, "com.sedmelluq", "lavaplayer")
                 .setUrl("https://github.com/sedmelluq/lavaplayer#lavaplayer---audio-player-library-for-discord")
                 .setAliases("lava", "player")
-                .setAnnouncmentRoleId(241948768113524762L)
+                .setAnnouncementRoleId(241948768113524762L)
                 .setAnnouncementChannelId(263484072389640193L)
         );
         addItem(new SimpleVersionedItem("JDA-Utilities", RepoType.JCENTER, DependencyType.POM, "com.jagrosh", "jda-utilities")
                 .setUrl("https://github.com/JDA-Applications/JDA-Utilities")
                 .setAliases("utils", "jda-utils")
+                .setAnnouncementRoleId(417331483091664896L)
+                .setAnnouncementChannelId(384483855475933184L)
         );
         //featured
         addItem(new YuiItem());

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
@@ -11,8 +11,9 @@ public class VersionCheckerRegistry
 
     public static void addItem(String name, String repoType, String groupId, String artifactId, String url)
     {
-        addItem(new SimpleVersionedItem(name, RepoType.fromString(repoType), DependencyType.DEFAULT,
-                groupId, artifactId, url, null));
+        addItem(new SimpleVersionedItem(name, RepoType.fromString(repoType), DependencyType.DEFAULT, groupId, artifactId)
+                .setUrl(url)
+        );
     }
 
     public static boolean addItem(VersionedItem item)
@@ -94,14 +95,16 @@ public class VersionCheckerRegistry
     {
         //Core
         addItem(new JDAItem());
-        addItem(new SimpleVersionedItem("Lavaplayer", RepoType.JCENTER, DependencyType.DEFAULT,
-                "com.sedmelluq", "lavaplayer",
-                "https://github.com/sedmelluq/lavaplayer#lavaplayer---audio-player-library-for-discord",
-                Arrays.asList("lava", "player")));
-        addItem(new SimpleVersionedItem("JDA-Utilities", RepoType.JCENTER, DependencyType.POM,
-                "com.jagrosh", "jda-utilities",
-                "https://github.com/JDA-Applications/JDA-Utilities",
-                Arrays.asList("utils", "jda-utils")));
+        addItem(new SimpleVersionedItem("Lavaplayer", RepoType.JCENTER, DependencyType.DEFAULT, "com.sedmelluq", "lavaplayer")
+                .setUrl("https://github.com/sedmelluq/lavaplayer#lavaplayer---audio-player-library-for-discord")
+                .setAliases("lava", "player")
+                .setAnnouncmentRoleId(241948768113524762L)
+                .setAnnouncementChannelId(263484072389640193L)
+        );
+        addItem(new SimpleVersionedItem("JDA-Utilities", RepoType.JCENTER, DependencyType.POM, "com.jagrosh", "jda-utilities")
+                .setUrl("https://github.com/JDA-Applications/JDA-Utilities")
+                .setAliases("utils", "jda-utils")
+        );
         //featured
         addItem(new YuiItem());
         addItem(new JDActionItem());

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
@@ -7,6 +7,9 @@ import java.util.stream.Collectors;
 
 public class VersionCheckerRegistry
 {
+    public static final VersionedItem EXPERIMENTAL_ITEM = new SimpleVersionedItem(null, null, null, null, null)
+            .setAnnouncementChannelId(289742061220134912L).setAnnouncementRoleId(289744006433472513L);
+
     private static final Map<String, VersionedItem> checkedItems = new LinkedHashMap<>();
 
     public static void addItem(String name, String repoType, String groupId, String artifactId, String url)
@@ -93,23 +96,36 @@ public class VersionCheckerRegistry
 
     private static void register()
     {
-        //Core
+        /*
+            CORE
+         */
+        //JDA
         addItem(new JDAItem());
+        //Lavaplayer
         addItem(new SimpleVersionedItem("Lavaplayer", RepoType.JCENTER, DependencyType.DEFAULT, "com.sedmelluq", "lavaplayer")
                 .setUrl("https://github.com/sedmelluq/lavaplayer#lavaplayer---audio-player-library-for-discord")
                 .setAliases("lava", "player")
-                .setAnnouncementRoleId(241948768113524762L)
-                .setAnnouncementChannelId(263484072389640193L)
+                .setAnnouncementRoleId(241948768113524762L)     //Lavaplayer Updates
+                .setAnnouncementChannelId(263484072389640193L)  //#lavaplayer
+                .addAnnouncementWhitelist(138092389008015360L)  //sedmelluq
         );
+        //JDA-Utilities
         addItem(new SimpleVersionedItem("JDA-Utilities", RepoType.JCENTER, DependencyType.POM, "com.jagrosh", "jda-utilities")
                 .setUrl("https://github.com/JDA-Applications/JDA-Utilities")
                 .setAliases("utils", "jda-utils")
-                .setAnnouncementRoleId(417331483091664896L)
-                .setAnnouncementChannelId(384483855475933184L)
+                .setAnnouncementRoleId(417331483091664896L)     //JDA-Utilities Updates
+                .setAnnouncementChannelId(384483855475933184L)  //#jda-utilities
+                .addAnnouncementWhitelist(113156185389092864L, 211393686628597761L) //Jagrosh, Shengaero (TheMonitorLizard)
         );
-        //featured
+        /*
+            FEATURED
+         */
+        //Yui
         addItem(new YuiItem());
+        //JDAction
         addItem(new JDActionItem());
-        //other
+        /*
+            OTHERS
+         */
     }
 }

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/items/JDAItem.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/items/JDAItem.java
@@ -53,6 +53,18 @@ public class JDAItem extends VersionedItem implements UpdateHandler
     }
 
     @Override
+    public long getAnnouncementRoleId()
+    {
+        return 241948671325765632L;
+    }
+
+    @Override
+    public long getAnnouncementChannelId()
+    {
+        return 125227483518861312L;
+    }
+
+    @Override
     public UpdateHandler getUpdateHandler()
     {
         return this;
@@ -64,6 +76,7 @@ public class JDAItem extends VersionedItem implements UpdateHandler
         return changelogProvider;
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Override
     public void onUpdate(VersionedItem item, String previousVersion, boolean shouldAnnounce)
     {
@@ -100,7 +113,9 @@ public class JDAItem extends VersionedItem implements UpdateHandler
 
             FormattingUtil.setFooter(eb, jenkinsBuild.culprits, jenkinsBuild.buildTime);
 
-            mb.append(Bot.getRoleJdaUpdates());
+            Role announcementRole = getAnnouncementRole();
+
+            mb.append(announcementRole.getAsMention());
 
             eb.setAuthor("JDA 3 version " + item.getVersion() + " has been released\n", JenkinsApi.JDA_JENKINS.jenkinsBase + versionSplits.build, EmbedUtil.JDA_ICON);
 
@@ -137,10 +152,9 @@ public class JDAItem extends VersionedItem implements UpdateHandler
 
             mb.build();
 
-            final Role role = Bot.getRoleJdaUpdates();
-            final TextChannel channel = Bot.getChannelAnnouncements();
+            final TextChannel channel = getAnnouncementChannel();
 
-            role.getManager().setMentionable(true).queue(s -> channel.sendMessage(mb.build()).queue(m -> role.getManager().setMentionable(false).queue()));
+            announcementRole.getManager().setMentionable(true).queue(s -> channel.sendMessage(mb.build()).queue(m -> announcementRole.getManager().setMentionable(false).queue()));
         }
     }
 }

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/items/SimpleVersionedItem.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/items/SimpleVersionedItem.java
@@ -3,6 +3,7 @@ package com.kantenkugel.discordbot.versioncheck.items;
 import com.kantenkugel.discordbot.versioncheck.DependencyType;
 import com.kantenkugel.discordbot.versioncheck.RepoType;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -13,7 +14,7 @@ import java.util.List;
 public class SimpleVersionedItem extends VersionedItem
 {
     private final String name;
-    private final List<String> aliases;
+    private List<String> aliases;
 
     private final RepoType repoType;
     private final DependencyType depType;
@@ -21,21 +22,40 @@ public class SimpleVersionedItem extends VersionedItem
     private final String artifactId;
 
     private String url;
+    private long roleId = 0;
+    private long channelId = 0;
 
-    public SimpleVersionedItem(String name, RepoType repoType, DependencyType depType, String groupId, String artifactId, List<String> aliases)
+    public SimpleVersionedItem(String name, RepoType repoType, DependencyType depType, String groupId, String artifactId)
     {
         this.name = name;
-        this.aliases = aliases;
         this.repoType = repoType;
         this.depType = depType;
         this.groupId = groupId;
         this.artifactId = artifactId;
     }
 
-    public SimpleVersionedItem(String name, RepoType repoType, DependencyType depType, String groupId, String artifactId, String url, List<String> aliases)
+    public SimpleVersionedItem setAliases(String... aliases)
     {
-        this(name, repoType, depType, groupId, artifactId, aliases);
+        this.aliases = Arrays.asList(aliases);
+        return this;
+    }
+
+    public SimpleVersionedItem setUrl(String url)
+    {
         this.url = url;
+        return this;
+    }
+
+    public SimpleVersionedItem setAnnouncmentRoleId(long roleId)
+    {
+        this.roleId = roleId;
+        return this;
+    }
+
+    public SimpleVersionedItem setAnnouncementChannelId(long channelId)
+    {
+        this.channelId = channelId;
+        return this;
     }
 
     @Override
@@ -78,5 +98,17 @@ public class SimpleVersionedItem extends VersionedItem
     public String getUrl()
     {
         return url;
+    }
+
+    @Override
+    public long getAnnouncementRoleId()
+    {
+        return roleId;
+    }
+
+    @Override
+    public long getAnnouncementChannelId()
+    {
+        return channelId;
     }
 }

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/items/SimpleVersionedItem.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/items/SimpleVersionedItem.java
@@ -2,6 +2,9 @@ package com.kantenkugel.discordbot.versioncheck.items;
 
 import com.kantenkugel.discordbot.versioncheck.DependencyType;
 import com.kantenkugel.discordbot.versioncheck.RepoType;
+import gnu.trove.set.TLongSet;
+import gnu.trove.set.hash.TLongHashSet;
+import net.dv8tion.jda.core.entities.User;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +27,7 @@ public class SimpleVersionedItem extends VersionedItem
     private String url;
     private long roleId = 0;
     private long channelId = 0;
+    private final TLongSet allowedAnnouncers = new TLongHashSet();
 
     public SimpleVersionedItem(String name, RepoType repoType, DependencyType depType, String groupId, String artifactId)
     {
@@ -55,6 +59,12 @@ public class SimpleVersionedItem extends VersionedItem
     public SimpleVersionedItem setAnnouncementChannelId(long channelId)
     {
         this.channelId = channelId;
+        return this;
+    }
+
+    public SimpleVersionedItem addAnnouncementWhitelist(long... userIds)
+    {
+        allowedAnnouncers.addAll(userIds);
         return this;
     }
 
@@ -110,5 +120,11 @@ public class SimpleVersionedItem extends VersionedItem
     public long getAnnouncementChannelId()
     {
         return channelId;
+    }
+
+    @Override
+    public boolean canAnnounce(User u)
+    {
+        return allowedAnnouncers.contains(u.getIdLong());
     }
 }

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/items/SimpleVersionedItem.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/items/SimpleVersionedItem.java
@@ -46,7 +46,7 @@ public class SimpleVersionedItem extends VersionedItem
         return this;
     }
 
-    public SimpleVersionedItem setAnnouncmentRoleId(long roleId)
+    public SimpleVersionedItem setAnnouncementRoleId(long roleId)
     {
         this.roleId = roleId;
         return this;

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/items/VersionedItem.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/items/VersionedItem.java
@@ -1,10 +1,13 @@
 package com.kantenkugel.discordbot.versioncheck.items;
 
+import com.almightyalpaca.discord.jdabutler.Bot;
 import com.kantenkugel.discordbot.versioncheck.UpdateHandler;
 import com.kantenkugel.discordbot.versioncheck.VersionUtils;
 import com.kantenkugel.discordbot.versioncheck.changelog.ChangelogProvider;
 import com.kantenkugel.discordbot.versioncheck.DependencyType;
 import com.kantenkugel.discordbot.versioncheck.RepoType;
+import net.dv8tion.jda.core.entities.Role;
+import net.dv8tion.jda.core.entities.TextChannel;
 
 import java.util.List;
 import java.util.Objects;
@@ -85,6 +88,31 @@ public abstract class VersionedItem
     }
 
     /**
+     * If this method returns a non-zero Role ID,
+     * this item integrates into the !notify command to toggle an announcement role.
+     *
+     * @return  Role ID of the announcement role, or {@code 0} (zero) if unused
+     */
+    public long getAnnouncementRoleId()
+    {
+        return 0;
+    }
+
+    /**
+     * If this method returns a non-zero TextChannel ID,
+     * this item integrates into the !announce command for custom announcements.
+     *
+     * <p>If {@link #getAnnouncementRoleId()} returns {@code 0}, then this is ignored,
+     * as announcements require a role.
+     *
+     * @return  TextChannel ID of the announcement channel, or {@code 0} (zero) if unused
+     */
+    public long getAnnouncementChannelId()
+    {
+        return 0;
+    }
+
+    /**
      * Hook to run custom code once a new version of this item is detected by JDA-Butler.
      *
      * @return  Null-able custom update handler
@@ -157,6 +185,18 @@ public abstract class VersionedItem
     public final void setVersion(String version)
     {
         this.version = version;
+    }
+
+    public final Role getAnnouncementRole()
+    {
+        long rid = getAnnouncementRoleId();
+        return rid == 0 ? null : Bot.getGuildJda().getRoleById(rid);
+    }
+
+    public final TextChannel getAnnouncementChannel()
+    {
+        long cid = getAnnouncementChannelId();
+        return cid == 0 ? null : Bot.getGuildJda().getTextChannelById(cid);
     }
 
     @Override

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/items/VersionedItem.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/items/VersionedItem.java
@@ -8,6 +8,7 @@ import com.kantenkugel.discordbot.versioncheck.DependencyType;
 import com.kantenkugel.discordbot.versioncheck.RepoType;
 import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.TextChannel;
+import net.dv8tion.jda.core.entities.User;
 
 import java.util.List;
 import java.util.Objects;
@@ -110,6 +111,21 @@ public abstract class VersionedItem
     public long getAnnouncementChannelId()
     {
         return 0;
+    }
+
+    /**
+     * This method is used to determine if some specific User can use announcements for this item (!announce command).
+     * Only used, when {@link #getAnnouncementRoleId()} and {@link #getAnnouncementChannelId()} are returning non-zero.
+     *
+     * <p>Note: JDA Staff can always use the announcement command and do therefore not require whitelisting through this method.
+     *
+     * @param u
+     *          The User which wants to make an announcement for this item
+     * @return  True, if the given User is allowed to make an announcement for this item
+     */
+    public boolean canAnnounce(User u)
+    {
+        return false;
     }
 
     /**


### PR DESCRIPTION
This PR continues on what i forgot to add to #21 and integrates the `!notify` and `!announce` commands into the new `VersionedItem` system.

This means following changes:
- Both `!notify` and `!announce` now look up the items via registry instead of statically programmed in Strings / IDs
- Added per-item whitelist to `!announce` command
- Added optional 3rd pipe delimited parameter (at first position) to `!announce` to manually set the role which should be announced
- `!notify` now defaults to the role(s) set up for the channel the command was executed in
- Changes to `VersionedItem`:
  - Added `long getAnnouncementRoleId()` which defaults to `0`
  - Added `long getAnnouncementChannelId()` which defaults to `0`
  - Added `boolean canAnnounce(User u)` which defaults to `false` (JDA Staff can always announce)