### PR TITLE
Add notify blacklist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     // JDA
-    compile group: 'net.dv8tion', name: 'JDA', version: '3.5.1_339'
+    compile group: 'net.dv8tion', name: 'JDA', version: '3.6.0_375'
 
     // Apache commons Lang 3
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/Bot.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/Bot.java
@@ -5,6 +5,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.filter.ThresholdFilter;
 import com.almightyalpaca.discord.jdabutler.commands.Dispatcher;
+import com.almightyalpaca.discord.jdabutler.commands.commands.NotifyCommand;
 import com.almightyalpaca.discord.jdabutler.config.Config;
 import com.almightyalpaca.discord.jdabutler.config.ConfigFactory;
 import com.almightyalpaca.discord.jdabutler.config.exception.KeyNotFoundException;
@@ -147,6 +148,8 @@ public class Bot
             Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
             root.addAppender(appender);
         }
+
+        NotifyCommand.reloadBlacklist(null);
 
         EXECUTOR.submit(() ->
         {

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
@@ -4,10 +4,17 @@ import com.almightyalpaca.discord.jdabutler.Bot;
 import com.almightyalpaca.discord.jdabutler.commands.Command;
 import com.kantenkugel.discordbot.versioncheck.VersionCheckerRegistry;
 import com.kantenkugel.discordbot.versioncheck.items.VersionedItem;
+import gnu.trove.set.TLongSet;
+import gnu.trove.set.hash.TLongHashSet;
+import net.dv8tion.jda.core.audit.ActionType;
+import net.dv8tion.jda.core.audit.AuditLogChange;
+import net.dv8tion.jda.core.audit.AuditLogKey;
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -15,7 +22,10 @@ import java.util.stream.Collectors;
 public class NotifyCommand implements Command
 {
 
+    private static final long BLACKLIST_CHANNEL_ID = 454657809397710859L;
     private static final String[] ALIASES = { "subscribe" };
+
+    private static final TLongSet BLACKLIST = new TLongHashSet();
 
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
@@ -26,6 +36,26 @@ public class NotifyCommand implements Command
         if (!guild.equals(Bot.getGuildJda()))
         {
             this.sendFailed(message);
+            return;
+        }
+
+        if(content.startsWith("blacklist"))
+        {
+            if(Bot.isAdmin(sender))
+            {
+                String subContent = content.substring(Math.min("blacklist".length() + 1, content.length()));
+                handleBlacklist(channel, message, subContent);
+            }
+            else
+            {
+                sendFailed(message);
+            }
+            return;
+        }
+
+        if(BLACKLIST.contains(sender.getIdLong()))
+        {
+            message.addReaction("\uD83D\uDE49").queue();
             return;
         }
 
@@ -116,6 +146,174 @@ public class NotifyCommand implements Command
     public String getName()
     {
         return "notify";
+    }
+
+    public static void reloadBlacklist(TextChannel responseChannel)
+    {
+        TextChannel blacklistChannel = getBlacklistChannel();
+        BLACKLIST.clear();
+        blacklistChannel.getIterableHistory().forEachAsync(message ->
+        {
+            String[] split = message.getContentRaw().split("\\s+");
+            try
+            {
+                long userId = Long.parseUnsignedLong(split[0]);
+                BLACKLIST.add(userId);
+            }
+            catch(NumberFormatException ex)
+            {
+                if(responseChannel != null)
+                    responseChannel.sendMessageFormat("Message `%s` is not a valid blacklist message", message.getContentStripped()).queue();
+            }
+            return true;
+        }).thenRun(() ->
+        {
+            if(responseChannel != null)
+                responseChannel.sendMessage("Reloaded " + BLACKLIST.size() + " users into blacklist").queue();
+        });
+    }
+
+    private void handleBlacklist(TextChannel channel, Message msg, String content)
+    {
+        if(content.isEmpty())
+        {
+            sendFailed(msg);
+            return;
+        }
+        String[] args = content.split("\\s+", 2);
+        TextChannel blacklistChannel = getBlacklistChannel();
+        switch(args[0].toLowerCase())
+        {
+            case "fetch":
+            case "get":
+                TextChannel searchChannel = msg.getMentionedChannels().isEmpty()
+                        ? VersionCheckerRegistry.getItem("jda").getAnnouncementChannel()
+                        : msg.getMentionedChannels().get(0);
+                if(searchChannel == null)
+                    channel.sendMessage("Could not determine channel to search in").queue();
+                else
+                    fetchBlacklist(searchChannel, channel);
+                break;
+            case "update":
+            case "import":
+            case "reload":
+                reloadBlacklist(channel);
+                break;
+            case "add":
+                msg.getMentionedUsers().forEach(u ->
+                {
+                    if(!BLACKLIST.contains(u.getIdLong()))
+                    {
+                        BLACKLIST.add(u.getIdLong());
+                        sendBlacklistAdditionMessage(blacklistChannel, u);
+                    }
+                });
+                msg.addReaction("\u2705").queue();
+                break;
+            case "rm":
+            case "remove":
+                TLongSet removedIds = new TLongHashSet();
+                msg.getMentionedUsers().forEach(u ->
+                {
+                    if(BLACKLIST.contains(u.getIdLong()))
+                    {
+                        BLACKLIST.remove(u.getIdLong());
+                        removedIds.add(u.getIdLong());
+                    }
+                });
+                removeFromChannel(blacklistChannel, removedIds);
+                msg.addReaction("\u2705").queue();
+                break;
+            default:
+                channel.sendMessage("Unknown modi").queue();
+        }
+    }
+
+    private void fetchBlacklist(TextChannel searchChannel, TextChannel responseChannel)
+    {
+        Message mentionMessage = searchChannel.getIterableHistory().stream()
+                .filter(message -> message.getAuthor().isBot() && !message.getMentionedRoles().isEmpty())
+                .limit(500).findFirst().orElse(null);
+        if(mentionMessage == null)
+        {
+            responseChannel.sendMessage("Could not find announcement message within 500 messages").queue();
+            return;
+        }
+
+        Role announcementRole = mentionMessage.getMentionedRoles().get(0);
+        OffsetDateTime abortTime = mentionMessage.getCreationTime();
+
+        TLongSet blacklistedUsers = new TLongHashSet();
+
+        searchChannel.getGuild().getAuditLogs().type(ActionType.MEMBER_ROLE_UPDATE).forEachAsync(log ->
+        {
+            if(log.getCreationTime().isBefore(abortTime))
+                return false;
+            AuditLogChange removedRoles = log.getChangeByKey(AuditLogKey.MEMBER_ROLES_REMOVE);
+            if(removedRoles == null)
+                return true;
+
+            if(log.getUser() == null || log.getUser().isBot() || !Bot.isAdmin(log.getUser()))
+                return true;
+
+
+            List<Map<String, String>> removedRoleMap = removedRoles.getNewValue();
+            if(removedRoleMap.stream().mapToLong(map -> Long.parseUnsignedLong(map.get("id"))).noneMatch(rem -> rem == announcementRole.getIdLong()))
+                return true;
+
+            blacklistedUsers.add(log.getTargetIdLong());
+
+            return true;
+        }).thenRun(() ->
+        {
+            if(blacklistedUsers.isEmpty() || (blacklistedUsers.removeAll(BLACKLIST) && blacklistedUsers.isEmpty()))
+            {
+                responseChannel.sendMessage("No1 matching blacklist criteria found!").queue();
+                return;
+            }
+            BLACKLIST.addAll(blacklistedUsers);
+            TextChannel blacklistChannel = getBlacklistChannel();
+            blacklistedUsers.forEach(userId ->
+            {
+                sendBlacklistAdditionMessage(blacklistChannel, Bot.jda.getUserById(userId));
+                return true;
+            });
+            responseChannel.sendMessage("Added " + blacklistedUsers.size() + " users to notify blacklist").queue();
+        });
+    }
+
+    private static void sendBlacklistAdditionMessage(TextChannel blacklistChannel, User blacklisted)
+    {
+        blacklistChannel.sendMessageFormat("%d - %#s", blacklisted.getIdLong(), blacklisted).queue();
+    }
+
+    private static void removeFromChannel(TextChannel blacklistChannel, TLongSet toRemove)
+    {
+        if(toRemove.isEmpty())
+            return;
+        blacklistChannel.getIterableHistory().forEachAsync(msg ->
+        {
+            String[] splits = msg.getContentRaw().split("\\s+");
+            try
+            {
+                long idFromMessage = Long.parseUnsignedLong(splits[0]);
+                if(toRemove.contains(idFromMessage))
+                {
+                    toRemove.remove(idFromMessage);
+                    msg.delete().queue();
+                    if(toRemove.isEmpty())
+                        return false;
+                }
+            }
+            catch(NumberFormatException ignored) {}
+
+            return true;
+        });
+    }
+
+    private static TextChannel getBlacklistChannel()
+    {
+        return Bot.jda.getTextChannelById(BLACKLIST_CHANNEL_ID);
     }
 
     private static void respond(Message origMsg, String newMessageContent)

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
@@ -185,6 +185,7 @@ public class NotifyCommand implements Command
         switch(args[0].toLowerCase())
         {
             case "fetch":
+            case "generate":
             case "get":
                 TextChannel searchChannel = msg.getMentionedChannels().isEmpty()
                         ? VersionCheckerRegistry.getItem("jda").getAnnouncementChannel()


### PR DESCRIPTION
This adds a blacklist for the notify command.

Changes include
- Blacklist sub-command of !notify (Staff only)
  - `fetch`/`generate`/`get` sub-commands import from mentioned channel or default update channel, by checking audit logs up to latest announcement
  - `update`/`reload`/`import` re-import from the text-channel db (described below)
  - `add` adds all mentioned users to the blacklist
  - `rm`/`remove` remove all mentioned users from the blacklist
- TextChannel as a database (especially useful for synchronization between the 2 butler bots)
- Blacklisted users are blocked from using !notify (duh)

Notes:
- Maybe optimize sub-command names for fetch/import (as a lot of names are ambiguous and could mean both types
- Once both this and #24 (Fakebutler) are merged (if fakebutler is merged), execute a db-import on un-stealthing