### PR TITLE
Add command message -> response message linking

### DIFF
--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Command.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Command.java
@@ -13,11 +13,19 @@ public abstract class Command
 {
     private static final FixedSizeCache<Long, TLongSet> MESSAGE_LINK_MAP = new FixedSizeCache<>(20);
 
-    public static void removeResponses(TextChannel channel, long messageId)
+    static void removeResponses(TextChannel channel, long messageId, ReactionListenerRegistry reactionRegistry)
     {
         TLongSet responses = MESSAGE_LINK_MAP.get(messageId);
         if(responses != null)
+        {
+            //if the responses had a reaction listener attached, clear it (cancel() is NOP if the id is not registered)
+            responses.forEach(msgId ->
+            {
+                reactionRegistry.cancel(msgId);
+                return true;
+            });
             channel.purgeMessagesById(responses.toArray());
+        }
     }
 
     public static void linkMessage(long commandId, long responseId)

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Command.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Command.java
@@ -1,26 +1,89 @@
 package com.almightyalpaca.discord.jdabutler.commands;
 
-import net.dv8tion.jda.core.entities.Message;
-import net.dv8tion.jda.core.entities.TextChannel;
-import net.dv8tion.jda.core.entities.User;
+import com.almightyalpaca.discord.jdabutler.util.FixedSizeCache;
+import gnu.trove.set.TLongSet;
+import gnu.trove.set.hash.TLongHashSet;
+import net.dv8tion.jda.core.MessageBuilder;
+import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
-public interface Command
-{
-    void dispatch(User sender, TextChannel channel, Message message, String content, GuildMessageReceivedEvent event);
+import java.util.function.Consumer;
 
-    default String[] getAliases()
+public abstract class Command
+{
+    private static final FixedSizeCache<Long, TLongSet> MESSAGE_LINK_MAP = new FixedSizeCache<>(20);
+
+    public static void removeResponses(TextChannel channel, long messageId)
+    {
+        TLongSet responses = MESSAGE_LINK_MAP.get(messageId);
+        if(responses != null)
+            channel.purgeMessagesById(responses.toArray());
+    }
+
+    public static void linkMessage(long commandId, long responseId)
+    {
+        TLongSet set;
+        if(!MESSAGE_LINK_MAP.contains(commandId))
+        {
+            set = new TLongHashSet(2);
+            MESSAGE_LINK_MAP.add(commandId, set);
+        }
+        else
+        {
+            set = MESSAGE_LINK_MAP.get(commandId);
+        }
+        set.add(responseId);
+    }
+
+    public abstract void dispatch(User sender, TextChannel channel, Message message, String content, GuildMessageReceivedEvent event);
+
+    public String[] getAliases()
     {
         return new String[0];
     }
 
-    String getHelp();
+    public abstract String getHelp();
 
-    String getName();
+    public abstract String getName();
 
-    default void sendFailed(final Message message)
+    protected void sendFailed(final Message message)
     {
         message.addReaction("❌").queue();
+    }
+
+    protected void reply(GuildMessageReceivedEvent event, String message)
+    {
+        reply(event, message, null);
+    }
+
+    protected void reply(GuildMessageReceivedEvent event, String message, Consumer<Message> successConsumer)
+    {
+        reply(event, new MessageBuilder(message).build(), successConsumer);
+    }
+
+    protected void reply(GuildMessageReceivedEvent event, MessageEmbed embed)
+    {
+        reply(event, embed, null);
+    }
+
+    protected void reply(GuildMessageReceivedEvent event, MessageEmbed embed, Consumer<Message> successConsumer)
+    {
+        reply(event, new MessageBuilder(embed).build(), successConsumer);
+    }
+
+    protected void reply(GuildMessageReceivedEvent event, Message message)
+    {
+        reply(event, message, null);
+    }
+
+    protected void reply(GuildMessageReceivedEvent event, Message message, Consumer<Message> successConsumer)
+    {
+        event.getChannel().sendMessage(message).queue(msg ->
+        {
+            linkMessage(event.getMessageIdLong(), msg.getIdLong());
+            if(successConsumer != null)
+                successConsumer.accept(msg);
+        });
     }
 
 }

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
@@ -101,7 +101,7 @@ public class Dispatcher extends ListenerAdapter
     @Override
     public void onGuildMessageDelete(GuildMessageDeleteEvent event)
     {
-        Command.removeResponses(event.getChannel(), event.getMessageIdLong());
+        Command.removeResponses(event.getChannel(), event.getMessageIdLong(), reactListReg);
     }
 
     @Override
@@ -154,38 +154,4 @@ public class Dispatcher extends ListenerAdapter
         return content;
     }
 
-    public static class ReactionListenerRegistry
-    {
-        private final Set<ReactionCommand.ReactionListener> listeners;
-
-        private ReactionListenerRegistry()
-        {
-            this.listeners = new HashSet<>();
-        }
-
-        public void register(final ReactionCommand.ReactionListener listener)
-        {
-            synchronized (this.listeners)
-            {
-                this.listeners.add(listener);
-            }
-        }
-
-        public void remove(final ReactionCommand.ReactionListener listener)
-        {
-            synchronized (this.listeners)
-            {
-                this.listeners.remove(listener);
-            }
-        }
-
-        private void handle(final MessageReactionAddEvent event)
-        {
-            synchronized (this.listeners)
-            {
-                for (final ReactionCommand.ReactionListener listener : this.listeners)
-                    listener.handle(event);
-            }
-        }
-    }
 }

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
@@ -7,6 +7,7 @@ import com.almightyalpaca.discord.jdabutler.util.MiscUtils;
 import com.google.common.util.concurrent.MoreExecutors;
 import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.events.ShutdownEvent;
+import net.dv8tion.jda.core.events.message.guild.GuildMessageDeleteEvent;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.core.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.core.hooks.ListenerAdapter;
@@ -98,6 +99,12 @@ public class Dispatcher extends ListenerAdapter
     }
 
     @Override
+    public void onGuildMessageDelete(GuildMessageDeleteEvent event)
+    {
+        Command.removeResponses(event.getChannel(), event.getMessageIdLong());
+    }
+
+    @Override
     public void onMessageReactionAdd(final MessageReactionAddEvent event)
     {
         this.reactListReg.handle(event);
@@ -132,7 +139,8 @@ public class Dispatcher extends ListenerAdapter
             }
             catch (final Exception e)
             {
-                event.getChannel().sendMessage("**There was an error processing your command!**").queue();
+                event.getChannel().sendMessage("**There was an error processing your command!**").queue(msg ->
+                        Command.linkMessage(event.getMessageIdLong(), msg.getIdLong()));
                 Bot.LOG.error("Error processing command {}", c.getName(), e);
             }
         });

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/ReactionCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/ReactionCommand.java
@@ -12,9 +12,10 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-public abstract class ReactionCommand implements Command
+public abstract class ReactionCommand extends Command
 {
-
+    //TODO: check how deletion from here mixes with command-response linking
+    //todo: move the reaction timeout threads to a threadpool
     public final static String[] NUMBERS = new String[]{"1\u20E3", "2\u20E3", "3\u20E3",
             "4\u20E3", "5\u20E3", "6\u20E3", "7\u20E3", "8\u20E3", "9\u20E3", "\uD83D\uDD1F"};
     public final static String[] LETTERS = new String[]{"\uD83C\uDDE6", "\uD83C\uDDE7", "\uD83C\uDDE8",
@@ -128,7 +129,7 @@ public abstract class ReactionCommand implements Command
 
         private void cleanup()
         {
-            registry.remove(ReactionListener.this);
+            registry.remove(this);
             if (shouldDeleteReactions)
             {
                 try

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/ReactionListenerRegistry.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/ReactionListenerRegistry.java
@@ -1,0 +1,154 @@
+package com.almightyalpaca.discord.jdabutler.commands;
+
+import com.almightyalpaca.discord.jdabutler.util.MiscUtils;
+import gnu.trove.map.TLongObjectMap;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.core.exceptions.PermissionException;
+import net.dv8tion.jda.core.utils.MiscUtil;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+public class ReactionListenerRegistry
+{
+    private static final ScheduledExecutorService EXECUTOR = Executors.newScheduledThreadPool(5,
+            MiscUtils.newThreadFactory("reaction-listener"));
+
+    private final TLongObjectMap<ReactionListener> listeners = MiscUtil.newLongMap();
+
+    ReactionListenerRegistry() {}
+
+    boolean hasListener(long messageId)
+    {
+        return this.listeners.containsKey(messageId);
+    }
+
+    void newListener(Message message, List<String> allowedReactions, Set<User> allowedUsers,
+                     int timeout, TimeUnit timeUnit, Consumer<Integer> callback)
+    {
+        new ReactionListener(message, allowedReactions, allowedUsers, timeout, timeUnit, callback);
+    }
+
+    private void register(long messageId, ReactionListener listener)
+    {
+        this.listeners.put(messageId, listener);
+    }
+
+    private void remove(long messageId)
+    {
+        this.listeners.remove(messageId);
+    }
+
+    void handle(final MessageReactionAddEvent event)
+    {
+        ReactionListener[] safeValues = this.listeners.values(new ReactionListener[this.listeners.size()]);
+        for (final ReactionListener listener : safeValues)
+            listener.handle(event);
+    }
+
+    void cancel(long messageId)
+    {
+        cancel(messageId, false);
+    }
+
+    void cancel(long messageId, boolean removeReactions)
+    {
+        ReactionListener reactionListener = this.listeners.get(messageId);
+        if(reactionListener != null)
+        {
+            reactionListener.stop(removeReactions);
+        }
+    }
+
+    private final class ReactionListener
+    {
+        private final Message message;
+        private final List<String> allowedReactions;
+        private final Set<User> allowedUsers;
+        private final Consumer<Integer> callback;
+        private final ScheduledFuture<?> timeoutFuture;
+
+        private boolean shouldDeleteReactions = true;
+
+        private ReactionListener(Message message, List<String> allowedReactions, Set<User> allowedUsers,
+                                int timeout, TimeUnit timeUnit, Consumer<Integer> callback)
+        {
+            ReactionListenerRegistry.this.register(message.getIdLong(), this);
+            this.message = message;
+            this.allowedReactions = allowedReactions;
+            this.allowedUsers = allowedUsers;
+            this.callback = callback;
+            this.timeoutFuture = ReactionListenerRegistry.EXECUTOR.schedule(this::cleanup, timeout, timeUnit);
+            addReactions();
+        }
+
+        private void handle(MessageReactionAddEvent event)
+        {
+            if (event.getMessageIdLong() != message.getIdLong())
+                return;
+            if (event.getUser() == event.getJDA().getSelfUser())
+                return;
+
+            try
+            {
+                event.getReaction().removeReaction(event.getUser()).queue();
+            } catch (PermissionException ignored) {}
+
+            if (!allowedUsers.isEmpty() && !allowedUsers.contains(event.getUser()))
+                return;
+
+            MessageReaction.ReactionEmote reactionEmote = event.getReactionEmote();
+            String reaction = reactionEmote.isEmote() ? reactionEmote.getEmote().getId() : reactionEmote.getName();
+            if (allowedReactions.contains(reaction))
+                callback.accept(allowedReactions.indexOf(reaction));
+        }
+
+        private void addReactions()
+        {
+            if (message.getChannelType() == ChannelType.TEXT && !message.getGuild().getSelfMember().hasPermission(Permission.MESSAGE_ADD_REACTION))
+                return;
+            for (String reaction : allowedReactions)
+            {
+                Emote emote = null;
+                try
+                {
+                    emote = message.getJDA().getEmoteById(reaction);
+                } catch (NumberFormatException ignored) {}
+                if (emote == null)
+                {
+                    message.addReaction(reaction).queue();
+                }
+                else
+                {
+                    message.addReaction(emote).queue();
+                }
+            }
+        }
+
+        private void stop(boolean removeReactions)
+        {
+            this.shouldDeleteReactions = removeReactions;
+            this.timeoutFuture.cancel(true);
+            cleanup();
+        }
+
+        private void cleanup()
+        {
+            ReactionListenerRegistry.this.remove(message.getIdLong());
+            if (shouldDeleteReactions)
+            {
+                try
+                {
+                    message.clearReactions().queue();
+                } catch (PermissionException ignored) {}
+            }
+        }
+    }
+}

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/AnnouncementCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/AnnouncementCommand.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 import static com.kantenkugel.discordbot.versioncheck.VersionCheckerRegistry.EXPERIMENTAL_ITEM;
 
-public class AnnouncementCommand implements Command
+public class AnnouncementCommand extends Command
 {
 
     @Override
@@ -58,7 +58,7 @@ public class AnnouncementCommand implements Command
                 VersionedItem item = VersionCheckerRegistry.getItem(args[0]);
                 if(item == null)
                 {
-                    channel.sendMessage("Item with name " + args[0] + " doesn't exist!").queue();
+                    reply(event, "Item with name " + args[0] + " doesn't exist!");
                     return;
                 }
                 if(!item.canAnnounce(sender) && !Bot.isAdmin(sender))
@@ -71,7 +71,7 @@ public class AnnouncementCommand implements Command
                     image = EmbedUtil.JDA_ICON;
                 if(role == null)
                 {
-                    channel.sendMessage("This item has no announcement role set up!").queue();
+                    reply(event, "This item has no announcement role set up!");
                     return;
                 }
             }
@@ -87,21 +87,21 @@ public class AnnouncementCommand implements Command
             switch(items.size())
             {
                 case 0:
-                    channel.sendMessage("No roles set up for this channel or you do not have access to them").queue();
+                    reply(event, "No roles set up for this channel or you do not have access to them");
                     return;
                 case 1:
                     VersionedItem item = items.get(0);
                     role = item.getAnnouncementRole();
                     if(role == null)
                     {
-                        channel.sendMessage("Item has invalid role id set up").queue();
+                        reply(event, "Item has invalid role id set up");
                         return;
                     }
                     if(item.getName().equalsIgnoreCase("jda") || item == EXPERIMENTAL_ITEM)
                         image = EmbedUtil.JDA_ICON;
                     break;
                 default:
-                    channel.sendMessage("Too many roles set up for this channel. You have to manually specify one via command.").queue();
+                    reply(event, "Too many roles set up for this channel. You have to manually specify one via command.");
                     return;
             }
         }

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/BuildGradleCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/BuildGradleCommand.java
@@ -13,7 +13,7 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class BuildGradleCommand implements Command
+public class BuildGradleCommand extends Command
 {
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
@@ -28,7 +28,7 @@ public class BuildGradleCommand implements Command
         final boolean pretty = content.contains("pretty");
 
         mb.appendCodeBlock(GradleUtil.getBuildFile(GradleUtil.DEFAULT_PLUGINS, "com.example.jda.Bot", "1.0", "1.8", items, pretty), "gradle");
-        channel.sendMessage(mb.build()).queue();
+        reply(event, mb.build());
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/ChangelogCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/ChangelogCommand.java
@@ -15,7 +15,7 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
 import java.util.List;
 
-public class ChangelogCommand implements Command
+public class ChangelogCommand extends Command
 {
 
     private static final String[] ALIASES = { "changes" };
@@ -44,15 +44,15 @@ public class ChangelogCommand implements Command
 
         if(clProvider == null)
         {
-            channel.sendMessage("No Changelogs set up for " + item.getName()).queue();
+            reply(event, "No Changelogs set up for " + item.getName());
             return;
         }
 
         //no version parameters or no version lookup supported
         if(!clProvider.supportsIndividualLogs() || args == null || args.length == versionStart)
         {
-            channel.sendMessage(String.format("Changelogs for %s can be found here: %s",
-                    item.getName(), clProvider.getChangelogUrl())).queue();
+            reply(event, String.format("Changelogs for %s can be found here: %s",
+                    item.getName(), clProvider.getChangelogUrl()));
             return;
         }
 
@@ -64,7 +64,7 @@ public class ChangelogCommand implements Command
             ChangelogProvider.Changelog changelog = clProvider.getChangelog(args[versionStart]);
             if(changelog == null)
             {
-                channel.sendMessage("The specified version does not exist").queue();
+                reply(event, "The specified version does not exist");
                 return;
             }
             if(changelog.getChangelogUrl() == null)
@@ -83,7 +83,7 @@ public class ChangelogCommand implements Command
             List<ChangelogProvider.Changelog> changelogs = clProvider.getChangelogs(args[versionStart], args[versionStart + 1]);
             if(changelogs.size() == 0)
             {
-                channel.sendMessage("No Changelogs found in given range").queue();
+                reply(event, "No Changelogs found in given range");
                 return;
             }
             int fields = 0;
@@ -110,11 +110,11 @@ public class ChangelogCommand implements Command
         MessageEmbed embed = eb.build();
         if(embed.isSendable(AccountType.BOT))
         {
-            channel.sendMessage(embed).queue();
+            reply(event, embed);
         }
         else
         {
-            channel.sendMessage("Too much content. Please restrict your build range").queue();
+            reply(event, "Too much content. Please restrict your build range");
         }
     }
 

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/DocsCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/DocsCommand.java
@@ -144,12 +144,12 @@ public class DocsCommand extends ReactionCommand
     {
         if (content.trim().isEmpty())
         {
-            channel.sendMessage(new MessageBuilder().append("See the docs here: ").append(JDocUtil.JDOCBASE).build()).queue();
+            reply(event, "See the docs here: " + JDocUtil.JDOCBASE);
             return;
         }
         if (content.trim().equalsIgnoreCase("help"))
         {
-            channel.sendMessage("Prints out JDA documentation.\n" +
+            reply(event, "Prints out JDA documentation.\n" +
                     "Syntax: `"+Bot.config.getString("prefix")+"docs [term | search:[params:]term | java:term | help]`.\n" +
                     "While not in special mode, `term` is a class name or a class-prefixed variable or method name (for example `JDA#getUserById`, `RestAction.queue()`).\n" +
                     "Both `.` and `#` can be used to specify inner classes, methods and variables.\n" +
@@ -162,7 +162,7 @@ public class DocsCommand extends ReactionCommand
                     "`c` to only search for classes\n" +
                     "`cs` to make matching case-sensitive\n\n" +
                     "When in `java` mode, java 8 docs are searched instead. Syntax for `term` is the same as without mode."
-            ).queue();
+            );
             return;
         }
         if (content.contains(":"))
@@ -170,7 +170,7 @@ public class DocsCommand extends ReactionCommand
             String[] split = content.split(":", 4);
             if (split.length > 3)
             {
-                channel.sendMessage("Invalid syntax!").queue();
+                reply(event, "Invalid syntax!");
                 return;
             }
             switch (split[0].toLowerCase())
@@ -181,7 +181,7 @@ public class DocsCommand extends ReactionCommand
                     Set<Documentation> search = JDoc.search(split[split.length - 1], options);
                     if (search.size() == 0)
                     {
-                        channel.sendMessage("Did not find anything matching query!").queue();
+                        reply(event, "Did not find anything matching query!");
                         return;
                     }
                     if (search.size() > RESULTS_PER_PAGE)
@@ -197,7 +197,7 @@ public class DocsCommand extends ReactionCommand
                             embedB.appendDescription('[' + documentation.getShortTitle() + "](" + documentation.getUrl(JDocUtil.JDOCBASE) + ")\n");
                         }
                         embedB.getDescriptionBuilder().setLength(embedB.getDescriptionBuilder().length() - 1);
-                        channel.sendMessage(embedB.build()).queue();
+                        reply(event, embedB.build());
                     }
                     break;
                 }
@@ -205,7 +205,7 @@ public class DocsCommand extends ReactionCommand
                 {
                     if (split.length != 2)
                     {
-                        channel.sendMessage("Invalid syntax!").queue();
+                        reply(event, "Invalid syntax!");
                         return;
                     }
 
@@ -213,10 +213,10 @@ public class DocsCommand extends ReactionCommand
                     switch (javadocs.size())
                     {
                         case 0:
-                            channel.sendMessage("No Result found!").queue();
+                            reply(event, "No Result found!");
                             break;
                         case 1:
-                            channel.sendMessage(getDocMessage(JDocUtil.JAVA_JDOCS_PREFIX, javadocs.get(0))).queue();
+                            reply(event, getDocMessage(JDocUtil.JAVA_JDOCS_PREFIX, javadocs.get(0)));
                             break;
                         default:
                             showRefinementEmbed(channel, sender, JDocUtil.JAVA_JDOCS_PREFIX, javadocs);
@@ -225,7 +225,7 @@ public class DocsCommand extends ReactionCommand
                     break;
                 }
                 default:
-                    channel.sendMessage("Unsupported operation " + split[0]).queue();
+                    reply(event, "Unsupported operation " + split[0]);
                     break;
             }
             return;
@@ -235,10 +235,10 @@ public class DocsCommand extends ReactionCommand
         switch (docs.size())
         {
             case 0:
-                channel.sendMessage("No Result found!").queue();
+                reply(event, "No Result found!");
                 break;
             case 1:
-                channel.sendMessage(getDocMessage(JDocUtil.JDOCBASE, docs.get(0))).queue();
+                reply(event, getDocMessage(JDocUtil.JDOCBASE, docs.get(0)));
                 break;
             default:
                 showRefinementEmbed(channel, sender, JDocUtil.JDOCBASE, docs);

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/EvalCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/EvalCommand.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class EvalCommand implements Command
+public class EvalCommand extends Command
 {
     private static final int TIMEOUT_S = 10;
 
@@ -64,7 +64,7 @@ public class EvalCommand implements Command
             event.getMessage().addReaction("✅").queue();
         else
             for (final Message m : builder.buildAll(SplitPolicy.NEWLINE, SplitPolicy.SPACE, SplitPolicy.ANYWHERE))
-                event.getChannel().sendMessage(m).queue();
+                reply(event, m);
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/GradleCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/GradleCommand.java
@@ -14,7 +14,7 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class GradleCommand implements Command
+public class GradleCommand extends Command
 {
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
@@ -37,7 +37,7 @@ public class GradleCommand implements Command
         eb.setDescription(description);
 
         EmbedUtil.setColor(eb);
-        channel.sendMessage(eb.build()).queue();
+        reply(event, eb.build());
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/GradleProjectCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/GradleProjectCommand.java
@@ -7,23 +7,23 @@ import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
-public class GradleProjectCommand implements Command
+public class GradleProjectCommand extends Command
 {
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
     {
         if (GradleProjectDropboxUtil.dropboxShareLink != null)
         {
-            channel.sendMessage(GradleProjectDropboxUtil.dropboxShareLink).queue();
+            reply(event, GradleProjectDropboxUtil.dropboxShareLink);
         }
         else if (GradleProjectDropboxUtil.ZIP_FILE.exists())
         {
             channel.sendTyping().queue();
-            channel.sendFile(GradleProjectDropboxUtil.ZIP_FILE).queue();
+            channel.sendFile(GradleProjectDropboxUtil.ZIP_FILE).queue(msg -> linkMessage(message.getIdLong(), msg.getIdLong()));
         }
         else
         {
-            channel.sendMessage("The example zip is currently not available").queue();
+            reply(event, "The example zip is currently not available");
         }
     }
 

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/GuildCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/GuildCommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
-public class GuildCommand implements Command
+public class GuildCommand extends Command
 {
 
     private static final String[] ALIASES = new String[]
@@ -16,7 +16,7 @@ public class GuildCommand implements Command
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
     {
-        channel.sendMessage(Bot.INVITE_LINK).queue();
+        reply(event, Bot.INVITE_LINK);
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/HelpCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/HelpCommand.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Comparator;
 import java.util.stream.Collectors;
 
-public class HelpCommand implements Command
+public class HelpCommand extends Command
 {
     private static final String[] ALIASES = new String[]
     { "info" };
@@ -32,7 +32,7 @@ public class HelpCommand implements Command
         final String help = Bot.dispatcher.getCommands().stream().sorted(Comparator.comparing(Command::getName)).filter(c -> c.getHelp() != null).map(c -> String.format("`%s` - %s", StringUtils.rightPad(prefix + c.getName().toLowerCase() + "", size, "."), c.getHelp())).collect(Collectors.joining("\n"));
         builder.setAuthor(channel.getGuild().getMember(sender).getEffectiveName(), null, sender.getEffectiveAvatarUrl());
         builder.setDescription(help);
-        channel.sendMessage(new MessageBuilder().setEmbed(builder.build()).build()).queue();
+        reply(event, new MessageBuilder().setEmbed(builder.build()).build());
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/JarsCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/JarsCommand.java
@@ -13,7 +13,7 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
 import java.io.IOException;
 
-public class JarsCommand implements Command
+public class JarsCommand extends Command
 {
     private static final String[] ALIASES = new String[]
     { "jar" };
@@ -32,7 +32,7 @@ public class JarsCommand implements Command
             JenkinsBuild lastBuild = JenkinsApi.JDA_JENKINS.getLastSuccessfulBuild();
             if(lastBuild == null)
             {
-                channel.sendMessage("Could not get Artifact-data from CI!").queue();
+                reply(event, "Could not get Artifact-data from CI!");
                 return;
             }
 
@@ -42,12 +42,12 @@ public class JarsCommand implements Command
             eb.addField("withDependencies", "[(normal)](" + lastBuild.artifacts.get("JDA-withDependencies").getLink() + ") " +
                     "[(no-opus)](" + lastBuild.artifacts.get("JDA-withDependencies-no-opus").getLink() + ")", true);
 
-            channel.sendMessage(eb.build()).queue();
+            reply(event, eb.build());
         }
         catch(IOException ex)
         {
             Bot.LOG.warn("Failed fetching latest build from Jenkins for Jars command", ex);
-            channel.sendMessage("CI was unreachable!").queue();
+            reply(event, "CI was unreachable!");
         }
     }
 

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/MavenCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/MavenCommand.java
@@ -14,7 +14,7 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class MavenCommand implements Command
+public class MavenCommand extends Command
 {
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
@@ -34,7 +34,7 @@ public class MavenCommand implements Command
         eb.setDescription(desc);
 
         EmbedUtil.setColor(eb);
-        channel.sendMessage(eb.build()).queue();
+        reply(event, eb.build());
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/MavenProjectCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/MavenProjectCommand.java
@@ -16,7 +16,7 @@ import java.io.InputStreamReader;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class MavenProjectCommand implements Command
+public class MavenProjectCommand extends Command
 {
     private static String POM;
 
@@ -48,7 +48,7 @@ public class MavenProjectCommand implements Command
         String repoString = MavenUtil.getRepositoryBlock(items, "    ");
 
         final String pom = String.format(MavenProjectCommand.POM, repoString, dependencyString);
-        channel.sendMessage("Here: " + MiscUtils.hastebin(pom) + ".xml").queue();
+        reply(event, "Here: " + MiscUtils.hastebin(pom) + ".xml");
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/PingCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/PingCommand.java
@@ -8,12 +8,12 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
 import java.time.temporal.ChronoUnit;
 
-public class PingCommand implements Command
+public class PingCommand extends Command
 {
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
     {
-        channel.sendMessage("Ping: ...").queue(m -> m.editMessage("Ping: " + message.getCreationTime().until(m.getCreationTime(), ChronoUnit.MILLIS) + "ms").queue());
+        reply(event, "Ping: ...", m -> m.editMessage("Ping: " + message.getCreationTime().until(m.getCreationTime(), ChronoUnit.MILLIS) + "ms").queue());
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/ShutdownCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/ShutdownCommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
-public class ShutdownCommand implements Command
+public class ShutdownCommand extends Command
 {
 
     private static final String[] ALIASES = new String[]

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/StatsCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/StatsCommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
-public class StatsCommand implements Command
+public class StatsCommand extends Command
 {
     private final FakeButlerListener fakeListener;
 
@@ -19,7 +19,7 @@ public class StatsCommand implements Command
     @Override
     public void dispatch(User sender, TextChannel channel, Message message, String content, GuildMessageReceivedEvent event)
     {
-        channel.sendMessage(fakeListener.getStats(event.getJDA())).queue();
+        reply(event, fakeListener.getStats(event.getJDA()));
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/UptimeCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/UptimeCommand.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
 import java.lang.management.ManagementFactory;
 
-public class UptimeCommand implements Command
+public class UptimeCommand extends Command
 {
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
@@ -34,7 +34,7 @@ public class UptimeCommand implements Command
         uptime = StringUtils.replaceLast(uptime, ", ", "");
         uptime = StringUtils.replaceLast(uptime, ",", " and");
 
-        channel.sendMessage(uptime).queue();
+        reply(event, uptime);
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/VersionsCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/VersionsCommand.java
@@ -12,7 +12,7 @@ import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
 import java.util.List;
 
-public class VersionsCommand implements Command
+public class VersionsCommand extends Command
 {
 
     private static final String[] ALIASES = { "version", "latest" };
@@ -52,7 +52,7 @@ public class VersionsCommand implements Command
             }
         }
 
-        channel.sendMessage(eb.build()).queue();
+        reply(event, eb.build());
     }
 
     @Override

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/moderation/SoftbanCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/moderation/SoftbanCommand.java
@@ -8,7 +8,7 @@ import net.dv8tion.jda.core.managers.GuildController;
 
 import java.util.List;
 
-public class SoftbanCommand implements Command
+public class SoftbanCommand extends Command
 {
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
@@ -16,14 +16,14 @@ public class SoftbanCommand implements Command
         final Member sendMem = event.getMember();
         if (!sendMem.hasPermission(Permission.KICK_MEMBERS))
         { // only kick cause its not perma ban
-            channel.sendMessage("WhO Do U thINk u Are?").queue();
+            sendFailed(message);
             return;
         }
 
         final List<User> mentions = message.getMentionedUsers();
         if (mentions.isEmpty())
         {
-            channel.sendMessage("PLeAse mENTion SOmEoNe!").queue();
+            reply(event, "Please mention someone");
             return;
         }
 

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/util/gradle/GradleProjectDropboxUtil.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/util/gradle/GradleProjectDropboxUtil.java
@@ -105,7 +105,7 @@ public class GradleProjectDropboxUtil
         createZip();
         init();
 
-        if (client == null)
+        if (client == null || Bot.config.getBoolean("testing", true))
         {
             Bot.LOG.info("Skipping upload!");
             return;


### PR DESCRIPTION
Adds a linking between the invoking command message and the response message(s) of the bot.

This will allow removal of all bot responses given if the corresponding initial command (message) was removed. Stray bot messages/embeds without calling command are therefore no longer a thing.

Currently, the size of the linking cache is configured to be `20` (incoming) messages (that have at least one response). But that number can be tweaked before merging.