### PR TITLE
[WIP] Move from notify blacklist to announcement mute role

### DIFF
--- a/src/main/java/com/almightyalpaca/discord/jdabutler/Bot.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/Bot.java
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.filter.ThresholdFilter;
 import com.almightyalpaca.discord.jdabutler.commands.Dispatcher;
-import com.almightyalpaca.discord.jdabutler.commands.commands.NotifyCommand;
 import com.almightyalpaca.discord.jdabutler.config.Config;
 import com.almightyalpaca.discord.jdabutler.config.ConfigFactory;
 import com.almightyalpaca.discord.jdabutler.config.exception.KeyNotFoundException;
@@ -50,38 +49,18 @@ public class Bot
 
     public static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor(MiscUtils.newThreadFactory("main-executor"));
 
-    public static Guild getGuildJda()
-    {
-        return Bot.jda.getGuildById("125227483518861312");
-    }
-
-    public static Role getRoleBots()
-    {
-        return Bot.getGuildJda().getRoleById("125616720156033024");
-    }
-
-    public static Role getRoleStaff()
-    {
-        return Bot.getGuildJda().getRoleById("169481978268090369");
-    }
-
     public static boolean isAdmin(final User user)
     {
-        final Member member = Bot.getGuildJda().getMember(user);
-        return member != null && member.getRoles().contains(Bot.getRoleStaff());
-    }
-
-    public static Role getRoleHelper()
-    {
-        return Bot.getGuildJda().getRoleById("183963327033114624");
+        final Member member = EntityLookup.getGuildJda().getMember(user);
+        return member != null && member.getRoles().contains(EntityLookup.getRoleStaff());
     }
 
     public static boolean isHelper(final User user)
     {
         if(isAdmin(user))
             return true;
-        final Member member = Bot.getGuildJda().getMember(user);
-        return member != null && member.getRoles().contains(Bot.getRoleHelper());
+        final Member member = EntityLookup.getGuildJda().getMember(user);
+        return member != null && member.getRoles().contains(EntityLookup.getRoleHelper());
     }
 
     public static void main(final String[] args) throws JsonIOException, JsonSyntaxException, WrongTypeException, KeyNotFoundException, IOException, LoginException, IllegalArgumentException, InterruptedException, SecurityException
@@ -135,8 +114,6 @@ public class Bot
             Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
             root.addAppender(appender);
         }
-
-        NotifyCommand.reloadBlacklist(null);
 
         EXECUTOR.submit(() ->
         {

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/EntityLookup.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/EntityLookup.java
@@ -1,0 +1,59 @@
+package com.almightyalpaca.discord.jdabutler;
+
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.Role;
+
+public class EntityLookup
+{
+
+    /*
+        JDA Guild
+     */
+    public static final long GUILD_JDA_ID = 125227483518861312L;
+    public static Guild getGuildJda()
+    {
+        return Bot.jda.getGuildById(GUILD_JDA_ID);
+    }
+
+    //ROLES
+    public static final long ROLE_BOTS_ID = 125616720156033024L;
+    public static Role getRoleBots()
+    {
+        return getGuildJda().getRoleById(ROLE_BOTS_ID);
+    }
+
+    public static final long ROLE_STAFF_ID = 169481978268090369L;
+    public static Role getRoleStaff()
+    {
+        return getGuildJda().getRoleById(ROLE_STAFF_ID);
+    }
+
+    public static final long ROLE_HELPERS_ID = 183963327033114624L;
+    public static Role getRoleHelper()
+    {
+        return getGuildJda().getRoleById(ROLE_HELPERS_ID);
+    }
+
+    //todo
+    public static final long ROLE_ANNOUNCEMUTE_ID = -1L;
+    public static Role getRoleAnnounceMute()
+    {
+        return getGuildJda().getRoleById(ROLE_ANNOUNCEMUTE_ID);
+    }
+
+
+    /*
+        DAPI Guild
+     */
+    public static final long GUILD_DAPI_ID = 81384788765712384L;
+
+    //CHANNELS/CATEGORIES
+    public static final long CHANNEL_DAPI_JDA_ID = 381889648827301889L;
+    public static final long CATEGORY_DAPI_TESTING_ID = 356505966201798656L;
+
+
+    /*
+        USERS
+     */
+    public static final long MAIN_BUTLER_ID = 189074312974696448L;
+}

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/EventListener.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/EventListener.java
@@ -21,11 +21,11 @@ public class EventListener extends ListenerAdapter
             if(user.isBot())
             {
                 final AuditableRestAction<Void> action = guild.getController()
-                        .addSingleRoleToMember(member, Bot.getRoleBots()).reason("Auto Role");
-                final String message = String.format("Added %#s (%d) to %s", user, user.getIdLong(), Bot.getRoleBots().getName());
+                        .addSingleRoleToMember(member, EntityLookup.getRoleBots()).reason("Auto Role");
+                final String message = String.format("Added %#s (%d) to %s", user, user.getIdLong(), EntityLookup.getRoleBots().getName());
                 action.queue(
                         v -> Bot.LOG.info(message),
-                        ex -> Bot.LOG.error("Could not add User {} to role {}", user.getName(), Bot.getRoleBots().getName(), ex)
+                        ex -> Bot.LOG.error("Could not add User {} to role {}", user.getName(), EntityLookup.getRoleBots().getName(), ex)
                 );
             }
         }

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
@@ -1,6 +1,7 @@
 package com.almightyalpaca.discord.jdabutler.commands;
 
 import com.almightyalpaca.discord.jdabutler.Bot;
+import com.almightyalpaca.discord.jdabutler.EntityLookup;
 import com.almightyalpaca.discord.jdabutler.commands.commands.*;
 import com.almightyalpaca.discord.jdabutler.commands.commands.moderation.SoftbanCommand;
 import com.almightyalpaca.discord.jdabutler.util.MiscUtils;
@@ -78,9 +79,9 @@ public class Dispatcher extends ListenerAdapter
 
         final TextChannel channel = event.getChannel();
 
-        if (channel.getGuild().getIdLong() == 81384788765712384L                                             // if DAPI
-            && !(channel.getIdLong() == 381889648827301889L                                                  // and not #java_jda
-                || (channel.getParent() != null && channel.getParent().getIdLong() == 356505966201798656L))) // or not testing category
+        if (channel.getGuild().getIdLong() == EntityLookup.GUILD_DAPI_ID                                     // if DAPI
+            && !(channel.getIdLong() == EntityLookup.CHANNEL_DAPI_JDA_ID                                     // and not #java_jda
+                || (channel.getParent() != null && channel.getParent().getIdLong() == EntityLookup.CATEGORY_DAPI_TESTING_ID))) // and not testing category
             return;                                                                                          // ignore message
 
         if (message.toLowerCase().startsWith(prefix.toLowerCase()))

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/AnnouncementCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/AnnouncementCommand.java
@@ -1,6 +1,7 @@
 package com.almightyalpaca.discord.jdabutler.commands.commands;
 
 import com.almightyalpaca.discord.jdabutler.Bot;
+import com.almightyalpaca.discord.jdabutler.EntityLookup;
 import com.almightyalpaca.discord.jdabutler.util.EmbedUtil;
 import com.almightyalpaca.discord.jdabutler.commands.Command;
 import com.almightyalpaca.discord.jdabutler.util.MiscUtils;
@@ -26,7 +27,7 @@ public class AnnouncementCommand extends Command
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
     {
-        if(!channel.getGuild().equals(Bot.getGuildJda()))
+        if(!channel.getGuild().equals(EntityLookup.getGuildJda()))
         {
             this.sendFailed(message);
             return;

--- a/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
+++ b/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/NotifyCommand.java
@@ -1,20 +1,14 @@
 package com.almightyalpaca.discord.jdabutler.commands.commands;
 
 import com.almightyalpaca.discord.jdabutler.Bot;
+import com.almightyalpaca.discord.jdabutler.EntityLookup;
 import com.almightyalpaca.discord.jdabutler.commands.Command;
 import com.kantenkugel.discordbot.versioncheck.VersionCheckerRegistry;
 import com.kantenkugel.discordbot.versioncheck.items.VersionedItem;
-import gnu.trove.set.TLongSet;
-import gnu.trove.set.hash.TLongHashSet;
-import net.dv8tion.jda.core.audit.ActionType;
-import net.dv8tion.jda.core.audit.AuditLogChange;
-import net.dv8tion.jda.core.audit.AuditLogKey;
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 
-import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -22,10 +16,7 @@ import java.util.stream.Collectors;
 public class NotifyCommand extends Command
 {
 
-    private static final long BLACKLIST_CHANNEL_ID = 454657809397710859L;
     private static final String[] ALIASES = { "subscribe" };
-
-    private static final TLongSet BLACKLIST = new TLongHashSet();
 
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
@@ -33,29 +24,9 @@ public class NotifyCommand extends Command
         final Member member = channel.getGuild().getMember(sender);
         final Guild guild = channel.getGuild();
 
-        if (!guild.equals(Bot.getGuildJda()))
+        if (!guild.equals(EntityLookup.getGuildJda()))
         {
             this.sendFailed(message);
-            return;
-        }
-
-        if(content.startsWith("blacklist"))
-        {
-            if(Bot.isAdmin(sender))
-            {
-                String subContent = content.substring(Math.min("blacklist".length() + 1, content.length()));
-                handleBlacklist(event, message, subContent);
-            }
-            else
-            {
-                sendFailed(message);
-            }
-            return;
-        }
-
-        if(BLACKLIST.contains(sender.getIdLong()))
-        {
-            message.addReaction("\uD83D\uDE49").queue();
             return;
         }
 
@@ -146,177 +117,6 @@ public class NotifyCommand extends Command
     public String getName()
     {
         return "notify";
-    }
-
-    public static void reloadBlacklist(GuildMessageReceivedEvent event)
-    {
-        TextChannel blacklistChannel = getBlacklistChannel();
-        BLACKLIST.clear();
-        blacklistChannel.getIterableHistory().forEachAsync(message ->
-        {
-            String[] split = message.getContentRaw().split("\\s+");
-            try
-            {
-                long userId = Long.parseUnsignedLong(split[0]);
-                BLACKLIST.add(userId);
-            }
-            catch(NumberFormatException ex)
-            {
-                if(event != null)
-                    event.getChannel().sendMessageFormat("Message `%s` is not a valid blacklist message", message.getContentStripped())
-                            .queue(msg -> linkMessage(event.getMessageIdLong(), msg.getIdLong()));
-            }
-            return true;
-        }).thenRun(() ->
-        {
-            if(event != null)
-                event.getChannel().sendMessage("Reloaded " + BLACKLIST.size() + " users into blacklist").queue(msg ->
-                        linkMessage(event.getMessageIdLong(), msg.getIdLong()));
-        });
-    }
-
-    private void handleBlacklist(GuildMessageReceivedEvent event, Message msg, String content)
-    {
-        if(content.isEmpty())
-        {
-            sendFailed(msg);
-            return;
-        }
-        String[] args = content.split("\\s+", 2);
-        TextChannel blacklistChannel = getBlacklistChannel();
-        switch(args[0].toLowerCase())
-        {
-            case "fetch":
-            case "generate":
-            case "get":
-                TextChannel searchChannel = msg.getMentionedChannels().isEmpty()
-                        ? VersionCheckerRegistry.getItem("jda").getAnnouncementChannel()
-                        : msg.getMentionedChannels().get(0);
-                if(searchChannel == null)
-                    reply(event, "Could not determine channel to search in");
-                else
-                    fetchBlacklist(searchChannel, event);
-                break;
-            case "update":
-            case "import":
-            case "reload":
-                reloadBlacklist(event);
-                break;
-            case "add":
-                msg.getMentionedUsers().forEach(u ->
-                {
-                    if(!BLACKLIST.contains(u.getIdLong()))
-                    {
-                        BLACKLIST.add(u.getIdLong());
-                        sendBlacklistAdditionMessage(blacklistChannel, u);
-                    }
-                });
-                msg.addReaction("\u2705").queue();
-                break;
-            case "rm":
-            case "remove":
-                TLongSet removedIds = new TLongHashSet();
-                msg.getMentionedUsers().forEach(u ->
-                {
-                    if(BLACKLIST.contains(u.getIdLong()))
-                    {
-                        BLACKLIST.remove(u.getIdLong());
-                        removedIds.add(u.getIdLong());
-                    }
-                });
-                removeFromChannel(blacklistChannel, removedIds);
-                msg.addReaction("\u2705").queue();
-                break;
-            default:
-                reply(event, "Unknown subcommand");
-        }
-    }
-
-    private void fetchBlacklist(TextChannel searchChannel, GuildMessageReceivedEvent event)
-    {
-        Message mentionMessage = searchChannel.getIterableHistory().stream()
-                .filter(message -> message.getAuthor().isBot() && !message.getMentionedRoles().isEmpty())
-                .limit(500).findFirst().orElse(null);
-        if(mentionMessage == null)
-        {
-            reply(event, "Could not find announcement message within 500 messages");
-            return;
-        }
-
-        Role announcementRole = mentionMessage.getMentionedRoles().get(0);
-        OffsetDateTime abortTime = mentionMessage.getCreationTime();
-
-        TLongSet blacklistedUsers = new TLongHashSet();
-
-        searchChannel.getGuild().getAuditLogs().type(ActionType.MEMBER_ROLE_UPDATE).forEachAsync(log ->
-        {
-            if(log.getCreationTime().isBefore(abortTime))
-                return false;
-            AuditLogChange removedRoles = log.getChangeByKey(AuditLogKey.MEMBER_ROLES_REMOVE);
-            if(removedRoles == null)
-                return true;
-
-            if(log.getUser() == null || log.getUser().isBot() || !Bot.isAdmin(log.getUser()))
-                return true;
-
-
-            List<Map<String, String>> removedRoleMap = removedRoles.getNewValue();
-            if(removedRoleMap.stream().mapToLong(map -> Long.parseUnsignedLong(map.get("id"))).noneMatch(rem -> rem == announcementRole.getIdLong()))
-                return true;
-
-            blacklistedUsers.add(log.getTargetIdLong());
-
-            return true;
-        }).thenRun(() ->
-        {
-            if(blacklistedUsers.isEmpty() || (blacklistedUsers.removeAll(BLACKLIST) && blacklistedUsers.isEmpty()))
-            {
-                reply(event, "No1 matching blacklist criteria found!");
-                return;
-            }
-            BLACKLIST.addAll(blacklistedUsers);
-            TextChannel blacklistChannel = getBlacklistChannel();
-            blacklistedUsers.forEach(userId ->
-            {
-                sendBlacklistAdditionMessage(blacklistChannel, Bot.jda.getUserById(userId));
-                return true;
-            });
-            reply(event, "Added " + blacklistedUsers.size() + " users to notify blacklist");
-        });
-    }
-
-    private static void sendBlacklistAdditionMessage(TextChannel blacklistChannel, User blacklisted)
-    {
-        blacklistChannel.sendMessageFormat("%d - %#s", blacklisted.getIdLong(), blacklisted).queue();
-    }
-
-    private static void removeFromChannel(TextChannel blacklistChannel, TLongSet toRemove)
-    {
-        if(toRemove.isEmpty())
-            return;
-        blacklistChannel.getIterableHistory().forEachAsync(msg ->
-        {
-            String[] splits = msg.getContentRaw().split("\\s+");
-            try
-            {
-                long idFromMessage = Long.parseUnsignedLong(splits[0]);
-                if(toRemove.contains(idFromMessage))
-                {
-                    toRemove.remove(idFromMessage);
-                    msg.delete().queue();
-                    if(toRemove.isEmpty())
-                        return false;
-                }
-            }
-            catch(NumberFormatException ignored) {}
-
-            return true;
-        });
-    }
-
-    private static TextChannel getBlacklistChannel()
-    {
-        return Bot.jda.getTextChannelById(BLACKLIST_CHANNEL_ID);
     }
 
     private static void respond(Message origMsg, String newMessageContent)

--- a/src/main/java/com/kantenkugel/discordbot/versioncheck/items/VersionedItem.java
+++ b/src/main/java/com/kantenkugel/discordbot/versioncheck/items/VersionedItem.java
@@ -1,6 +1,6 @@
 package com.kantenkugel.discordbot.versioncheck.items;
 
-import com.almightyalpaca.discord.jdabutler.Bot;
+import com.almightyalpaca.discord.jdabutler.EntityLookup;
 import com.kantenkugel.discordbot.versioncheck.UpdateHandler;
 import com.kantenkugel.discordbot.versioncheck.VersionUtils;
 import com.kantenkugel.discordbot.versioncheck.changelog.ChangelogProvider;
@@ -206,13 +206,13 @@ public abstract class VersionedItem
     public final Role getAnnouncementRole()
     {
         long rid = getAnnouncementRoleId();
-        return rid == 0 ? null : Bot.getGuildJda().getRoleById(rid);
+        return rid == 0 ? null : EntityLookup.getGuildJda().getRoleById(rid);
     }
 
     public final TextChannel getAnnouncementChannel()
     {
         long cid = getAnnouncementChannelId();
-        return cid == 0 ? null : Bot.getGuildJda().getTextChannelById(cid);
+        return cid == 0 ? null : EntityLookup.getGuildJda().getTextChannelById(cid);
     }
 
     @Override


### PR DESCRIPTION
**This PR is still WIP**

## Description

Removes the notify blacklist previously used and instead adds an announcment mute role.

This allows users to actually get notified about announcements but prevents them from spamming by revoking their WRITE permission.

This PR builds on the previously merged PR #29 , which added `MiscUtil.announce(...)`

## Todo

Below is a list of actually known Todo entries. Since this is still a WIP, there might be some significant changes to how everything works tho and the Todo list will update correspondingly.

- [ ] Create the mute role and fill in the ID in `EntityLookup`.
- [ ] Think of other names for `EntityLookup`. When i wrote the initial commit, i couldn't come up with a better name.