### PR TITLE
Fix multiple issues with JDoc indexing of Subclasses

### DIFF
--- a/src/main/java/com/kantenkugel/discordbot/jdocparser/JDoc.java
+++ b/src/main/java/com/kantenkugel/discordbot/jdocparser/JDoc.java
@@ -102,6 +102,7 @@ public class JDoc {
             }
             is = res.body().byteStream();
             JDocParser.parse(JDocUtil.JAVA_JDOCS_PREFIX, urlPath, is, resultMap);
+            resultMap.remove(JDocParser.SUBCLASSES_MAP_KEY);
         } catch(Exception e) {
             JDocUtil.LOG.error("Error parsing java javadocs for {}", name, e);
         } finally {


### PR DESCRIPTION
This PR fixes issues of how subclasses were indexed in the JDocs.

For example, it should now always be possible to reach subclass `A.B` by doing `!docs B`, unless there is a top-level class named `B` or there are more than only one subclass named `B`.