### PR TITLE
Properly close ALL RequestBodies

### DIFF
--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -28,8 +28,8 @@ dependencies {
     // Apache Commons IO
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
 
-    // Groovy JSR-223 / Script engine
-    compile group: 'org.codehaus.groovy', name: 'groovy-jsr223', version: '2.4.13'
+    // Groovy JSR-223 / Script engine. TODO: might change eval command to jshell in the future
+    compile group: 'org.codehaus.groovy', name: 'groovy-jsr223', version: '2.5.3'
 
     // Gson
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
@@ -55,9 +55,8 @@ public class MiscUtils
                         .build()
         ).execute())
         {
-            if(!response.isSuccessful()) {
+            if(!response.isSuccessful())
                 return null;
-            }
 
             ResponseBody body = response.body();
             if(body == null)

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
@@ -46,32 +46,26 @@ public class MiscUtils
 
     public static String hastebin(final String text)
     {
-        try
+        String server = "https://haste.kantenkugel.com/"; //requires trailing slash
+        try(Response response = Bot.httpClient.newCall(
+                new Request.Builder()
+                        .post(RequestBody.create(MediaType.parse("text/plain"), text))
+                        .url(server + "documents")
+                        .header("User-Agent", "Mozilla/5.0 JDA-Butler")
+                        .build()
+        ).execute())
         {
-            String server = "https://haste.kantenkugel.com/"; //requires trailing slash
-            Response response = Bot.httpClient.newCall(
-                    new Request.Builder()
-                            .post(RequestBody.create(MediaType.parse("text/plain"), text))
-                            .url(server + "documents")
-                            .header("User-Agent", "Mozilla/5.0 JDA-Butler")
-                            .build()
-            ).execute();
-
-            if(!response.isSuccessful())
-            {
-                response.close();
+            if(!response.isSuccessful()) {
                 return null;
             }
 
-            try(ResponseBody body = response.body())
-            {
-                if(body == null)
-                    throw new IOException("We received an OK response without body when POSTing to hastebin");
-                JSONObject obj = new JSONObject(new JSONTokener(body.charStream()));
-                return server + obj.getString("key");
-            }
-
+            ResponseBody body = response.body();
+            if(body == null)
+                throw new IOException("We received an OK response without body when POSTing to hastebin");
+            JSONObject obj = new JSONObject(new JSONTokener(body.charStream()));
+            return server + obj.getString("key");
         }
+
         catch (final Exception e)
         {
             Bot.LOG.warn("Error posting text to hastebin", e);

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
@@ -58,7 +58,10 @@ public class MiscUtils
             ).execute();
 
             if(!response.isSuccessful())
+            {
+                response.close();
                 return null;
+            }
 
             try(ResponseBody body = response.body())
             {

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
@@ -58,10 +58,7 @@ public class MiscUtils
             if(!response.isSuccessful())
                 return null;
 
-            ResponseBody body = response.body();
-            if(body == null)
-                throw new IOException("We received an OK response without body when POSTing to hastebin");
-            JSONObject obj = new JSONObject(new JSONTokener(body.charStream()));
+            JSONObject obj = new JSONObject(new JSONTokener(response.body().charStream()));
             return server + obj.getString("key");
         }
 

--- a/bot/src/main/java/com/kantenkugel/discordbot/graphql/GQLQuery.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/graphql/GQLQuery.java
@@ -124,15 +124,9 @@ public class GQLQuery<T>
             post.header("Authorization", auth);
         try(Response execute = Bot.httpClient.newCall(post.build()).execute())
         {
-            ResponseBody body = execute.body();
-            if(body == null)
-            {
-                LOG.error("Got empty body from GQL query");
-                return null;
-            }
             List<String> errors = new ArrayList<>();
             T object = null;
-            JsonReader reader = GSON.newJsonReader(body.charStream());
+            JsonReader reader = GSON.newJsonReader(execute.body().charStream());
             reader.beginObject();
             while(reader.hasNext())
             {

--- a/bot/src/main/java/com/kantenkugel/discordbot/graphql/GQLQuery.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/graphql/GQLQuery.java
@@ -122,64 +122,61 @@ public class GQLQuery<T>
         Request.Builder post = new Request.Builder().url(remoteUrl).post(RequestBody.create(jsonType, data.toString().getBytes()));
         if(auth != null)
             post.header("Authorization", auth);
-        try
+        try(Response execute = Bot.httpClient.newCall(post.build()).execute())
         {
-            Response execute = Bot.httpClient.newCall(post.build()).execute();
-            try(ResponseBody body = execute.body())
+            ResponseBody body = execute.body();
+            if(body == null)
             {
-                if(body == null)
-                {
-                    LOG.error("Got empty body from GQL query");
-                    return null;
-                }
-                List<String> errors = new ArrayList<>();
-                T object = null;
-                JsonReader reader = GSON.newJsonReader(body.charStream());
-                reader.beginObject();
-                while(reader.hasNext())
-                {
-                    String name = reader.nextName();
-                    switch (name)
-                    {
-                        case "errors":
-                            readErrors(errors, reader);
-                            break;
-                        case "data":
-                            if (reader.peek() == JsonToken.BEGIN_OBJECT)
-                            {
-                                reader.beginObject();
-                                reader.nextName();
-                                object = GSON.fromJson(reader, clazz);
-                                reader.endObject();
-                            }
-                            else
-                            {
-                                reader.skipValue();
-                            }
-                            break;
-                        default:
-                            reader.skipValue();
-                            break;
-                    }
-                }
-                reader.endObject();
-                reader.close();
-                if(!errors.isEmpty())
-                {
-                    LOG.error("There was at least one GQL error:\n{}", JDALogger.getLazyString(() ->
-                    {
-                        StringBuilder b = new StringBuilder();
-                        for(String error : errors)
-                        {
-                            b.append(error).append('\n');
-                        }
-                        b.setLength(b.length() - 1);
-                        return b.toString();
-                    }));
-                    return null;
-                }
-                return object;
+                LOG.error("Got empty body from GQL query");
+                return null;
             }
+            List<String> errors = new ArrayList<>();
+            T object = null;
+            JsonReader reader = GSON.newJsonReader(body.charStream());
+            reader.beginObject();
+            while(reader.hasNext())
+            {
+                String name = reader.nextName();
+                switch (name)
+                {
+                    case "errors":
+                        readErrors(errors, reader);
+                        break;
+                    case "data":
+                        if (reader.peek() == JsonToken.BEGIN_OBJECT)
+                        {
+                            reader.beginObject();
+                            reader.nextName();
+                            object = GSON.fromJson(reader, clazz);
+                            reader.endObject();
+                        }
+                        else
+                        {
+                            reader.skipValue();
+                        }
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            reader.close();
+            if(!errors.isEmpty())
+            {
+                LOG.error("There was at least one GQL error:\n{}", JDALogger.getLazyString(() ->
+                {
+                    StringBuilder b = new StringBuilder();
+                    for(String error : errors)
+                    {
+                        b.append(error).append('\n');
+                    }
+                    b.setLength(b.length() - 1);
+                    return b.toString();
+                }));
+                return null;
+            }
+            return object;
         }
         catch(SocketTimeoutException ex)
         {

--- a/bot/src/main/java/com/kantenkugel/discordbot/jdocparser/JDoc.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/jdocparser/JDoc.java
@@ -93,21 +93,19 @@ public class JDoc {
         }
 
         Map<String, JDocParser.ClassDocumentation> resultMap = new HashMap<>();
-        InputStream is = null;
         try {
             Response res = Bot.httpClient.newCall(new Request.Builder().url(JDocUtil.JAVA_JDOCS_PREFIX+urlPath).get().build()).execute();
             if(!res.isSuccessful()) {
+                res.close();
                 JDocUtil.LOG.warn("OkHttp returned failure for java8 index: "+res.code());
                 return Collections.emptyList();
             }
-            is = res.body().byteStream();
-            JDocParser.parse(JDocUtil.JAVA_JDOCS_PREFIX, urlPath, is, resultMap);
-            resultMap.remove(JDocParser.SUBCLASSES_MAP_KEY);
+            try(ResponseBody body = res.body()) {
+                JDocParser.parse(JDocUtil.JAVA_JDOCS_PREFIX, urlPath, body.byteStream(), resultMap);
+                resultMap.remove(JDocParser.SUBCLASSES_MAP_KEY);
+            }
         } catch(Exception e) {
             JDocUtil.LOG.error("Error parsing java javadocs for {}", name, e);
-        } finally {
-            if(is != null)
-                try { is.close(); } catch(Exception ignored) {}
         }
 
         if(!resultMap.containsKey(className)) {
@@ -212,8 +210,7 @@ public class JDoc {
         List<JDocParser.MethodDocumentation> filteredDocs = docs.parallelStream()
                 .filter(doc -> doc.matches(methodSig, isFuzzy))
                 .collect(Collectors.toList());
-        switch (filteredDocs.size())
-        {
+        switch (filteredDocs.size()) {
             case 1:
                 return Collections.singletonList(filteredDocs.get(0));
             case 0:
@@ -256,45 +253,32 @@ public class JDoc {
     }
 
     private static void download() {
-        try
-        {
+        try {
             JenkinsBuild lastBuild = JenkinsApi.JDA_JENKINS.getLastSuccessfulBuild();
-            if(lastBuild != null)
-            {
+            if(lastBuild != null) {
                 JDocUtil.LOG.debug("Downloading JDA docs...");
-                ResponseBody body = null;
-                try
-                {
+                try {
                     String artifactUrl = lastBuild.artifacts.get("JDA-javadoc").getLink();
                     Response res = Bot.httpClient.newCall(new Request.Builder().url(artifactUrl).get().build()).execute();
-                    if(!res.isSuccessful())
-                    {
+                    if(!res.isSuccessful()) {
+                        res.close();
                         JDocUtil.LOG.warn("OkHttp returned failure for {}", artifactUrl);
                         return;
                     }
-                    body = res.body();
-                    final InputStream is = body.byteStream();
-                    Files.copy(is, JDocUtil.LOCAL_DOC_PATH, StandardCopyOption.REPLACE_EXISTING);
-                    is.close();
-                    JDocUtil.LOG.debug("Done downloading JDA docs");
+                    try(ResponseBody body = res.body()) {
+                        Files.copy(body.byteStream(), JDocUtil.LOCAL_DOC_PATH, StandardCopyOption.REPLACE_EXISTING);
+                        JDocUtil.LOG.debug("Done downloading JDA docs");
+                    }
                 }
-                catch(Exception e)
-                {
+                catch(Exception e) {
                     JDocUtil.LOG.error("Error downloading jdoc jar", e);
                 }
-                finally
-                {
-                    if(body != null)
-                        body.close();
-                }
             }
-            else
-            {
+            else {
                 JDocUtil.LOG.warn("There was no Jenkins build?! Skipping download");
             }
         }
-        catch(IOException ex)
-        {
+        catch(IOException ex) {
             JDocUtil.LOG.warn("Could not contact Jenkins, skipping download");
         }
     }
@@ -303,17 +287,19 @@ public class JDoc {
         try {
             Response res = Bot.httpClient.newCall(new Request.Builder().url(JDocUtil.JAVA_JDOCS_CLASS_INDEX).get().build()).execute();
             if(!res.isSuccessful()) {
+                res.close();
                 JDocUtil.LOG.warn("OkHttp returned failure for java8 index: "+res.code());
                 return;
             }
-            ResponseBody body = res.body();
-            Document docBody = Jsoup.parse(body.byteStream(), "UTF-8", JDocUtil.JAVA_JDOCS_PREFIX);
-            docBody.getElementsByClass("indexContainer").first().child(0).children().forEach(child -> {
-                Element link = child.child(0);
-                if(link.tagName().equals("a") && link.attr("href").startsWith("java/")) {
-                    javaJavaDocs.put(link.text().toLowerCase(), link.attr("href"));
-                }
-            });
+            try(ResponseBody body = res.body()) {
+                Document docBody = Jsoup.parse(body.byteStream(), "UTF-8", JDocUtil.JAVA_JDOCS_PREFIX);
+                docBody.getElementsByClass("indexContainer").first().child(0).children().forEach(child -> {
+                    Element link = child.child(0);
+                    if(link.tagName().equals("a") && link.attr("href").startsWith("java/")) {
+                        javaJavaDocs.put(link.text().toLowerCase(), link.attr("href"));
+                    }
+                });
+            }
         } catch(Exception e) {
             JDocUtil.LOG.error("Failed fetching the j8 class index", e);
         }

--- a/bot/src/main/java/com/kantenkugel/discordbot/jenkinsutil/JenkinsApi.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/jenkinsutil/JenkinsApi.java
@@ -4,6 +4,7 @@ import com.almightyalpaca.discord.jdabutler.Bot;
 import com.almightyalpaca.discord.jdabutler.util.FixedSizeCache;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.slf4j.Logger;
@@ -99,11 +100,17 @@ public class JenkinsApi
 
         Response res = Bot.httpClient.newCall(req).execute();
         if(!res.isSuccessful())
+        {
+            res.close();
             return null;
-        JenkinsBuild build = JenkinsBuild.fromJson(new JSONObject(new JSONTokener(res.body().charStream())), this);
-        if(build.status != JenkinsBuild.Status.BUILDING)
-            resultCache.add(build.buildNum, build);
-        return build;
+        }
+        try(ResponseBody body = res.body())
+        {
+            JenkinsBuild build = JenkinsBuild.fromJson(new JSONObject(new JSONTokener(body.charStream())), this);
+            if(build.status != JenkinsBuild.Status.BUILDING)
+                resultCache.add(build.buildNum, build);
+            return build;
+        }
     }
 
     private JenkinsApi(String jenkinsurl)

--- a/bot/src/main/java/com/kantenkugel/discordbot/jenkinsutil/JenkinsApi.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/jenkinsutil/JenkinsApi.java
@@ -4,7 +4,6 @@ import com.almightyalpaca.discord.jdabutler.Bot;
 import com.almightyalpaca.discord.jdabutler.util.FixedSizeCache;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.slf4j.Logger;
@@ -98,15 +97,11 @@ public class JenkinsApi
     {
         Request req = new Request.Builder().url(jenkinsBase + identifier + API_SUFFIX + BUILD_OPTIONS).get().build();
 
-        Response res = Bot.httpClient.newCall(req).execute();
-        if(!res.isSuccessful())
+        try(Response res = Bot.httpClient.newCall(req).execute())
         {
-            res.close();
-            return null;
-        }
-        try(ResponseBody body = res.body())
-        {
-            JenkinsBuild build = JenkinsBuild.fromJson(new JSONObject(new JSONTokener(body.charStream())), this);
+            if(!res.isSuccessful())
+                return null;
+            JenkinsBuild build = JenkinsBuild.fromJson(new JSONObject(new JSONTokener(res.body().charStream())), this);
             if(build.status != JenkinsBuild.Status.BUILDING)
                 resultCache.add(build.buildNum, build);
             return build;

--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionChecker.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionChecker.java
@@ -6,7 +6,6 @@ import com.kantenkugel.discordbot.versioncheck.items.VersionedItem;
 import net.dv8tion.jda.core.utils.tuple.Pair;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -42,7 +41,6 @@ public class VersionChecker
 
     static String getVersion(VersionedItem item)
     {
-        ResponseBody body = null;
         try
         {
             Supplier<String> versionSupplier = item.getCustomVersionSupplier();
@@ -52,42 +50,37 @@ public class VersionChecker
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 
-            Response res = Bot.httpClient.newCall(
-                    new Request.Builder().url(item.getRepoUrl()).get().build()
-            ).execute();
-
-            body = res.body();
-
-            if (!res.isSuccessful() || body == null)
+            try(Response res = Bot.httpClient.newCall(new Request.Builder()
+                    .url(item.getRepoUrl()).get().build()).execute())
             {
-                if(body != null)
-                    body.close();
-                LOG.warn("Could not fetch Maven metadata from " + item.getRepoUrl() + " - OkHttp returned with failure");
-                return null;
+
+                if (!res.isSuccessful())
+                {
+                    LOG.warn("Could not fetch Maven metadata from " + item.getRepoUrl() + " - OkHttp returned with failure");
+                    return null;
+                }
+
+                Document doc = dBuilder.parse(res.body().byteStream());
+
+                Element root = doc.getDocumentElement();
+                root.normalize();
+
+                Element versioningElem = (Element) root.getElementsByTagName("versioning").item(0);
+                if (versioningElem == null)
+                {
+                    LOG.warn("Could not find versioning node for item {}", item.getName());
+                    return null;
+                }
+
+                Element versionElem = (Element) versioningElem.getElementsByTagName("release").item(0);
+                if (versionElem == null)
+                {
+                    LOG.warn("Could not find release node for item {}", item.getName());
+                    return null;
+                }
+
+                return versionElem.getTextContent();
             }
-
-            Document doc = dBuilder.parse(body.byteStream());
-            body.close();
-
-            Element root = doc.getDocumentElement();
-            root.normalize();
-
-            Element versioningElem = (Element) root.getElementsByTagName("versioning").item(0);
-            if (versioningElem == null)
-            {
-                LOG.warn("Could not find versioning node for item {}", item.getName());
-                return null;
-            }
-
-            Element versionElem = (Element) versioningElem.getElementsByTagName("release").item(0);
-            if (versionElem == null)
-            {
-                LOG.warn("Could not find release node for item {}", item.getName());
-                return null;
-            }
-
-            return versionElem.getTextContent();
-
         }
         catch(SocketTimeoutException | UncheckedIOException ex)
         {
@@ -99,11 +92,6 @@ public class VersionChecker
         catch (Exception e)
         {
             LOG.error("Could not fetch version info for item {}", item.getName(), e);
-        }
-        finally
-        {
-            if(body != null)
-                body.close();
         }
         return null;
     }

--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionChecker.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionChecker.java
@@ -60,11 +60,14 @@ public class VersionChecker
 
             if (!res.isSuccessful() || body == null)
             {
+                if(body != null)
+                    body.close();
                 LOG.warn("Could not fetch Maven metadata from " + item.getRepoUrl() + " - OkHttp returned with failure");
                 return null;
             }
 
             Document doc = dBuilder.parse(body.byteStream());
+            body.close();
 
             Element root = doc.getDocumentElement();
             root.normalize();

--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/items/ButlerItem.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/items/ButlerItem.java
@@ -104,14 +104,13 @@ public class ButlerItem extends VersionedItem implements UpdateHandler
                 Response res = Bot.httpClient.newCall(new Request.Builder().url(bot.getLink()).get().build()).execute();
                 if(!res.isSuccessful())
                 {
+                    res.close();
                     LOG.warn("OkHttp returned failure for {}", bot.getLink());
                     return;
                 }
                 try(ResponseBody body = res.body())
                 {
-                    final InputStream is = body.byteStream();
-                    Files.copy(is, UPDATE_FILE, StandardCopyOption.REPLACE_EXISTING);
-                    is.close();
+                    Files.copy(body.byteStream(), UPDATE_FILE, StandardCopyOption.REPLACE_EXISTING);
                 }
             }
             catch(Exception e)

--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/items/ButlerItem.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/items/ButlerItem.java
@@ -8,10 +8,8 @@ import com.kantenkugel.discordbot.versioncheck.RepoType;
 import com.kantenkugel.discordbot.versioncheck.UpdateHandler;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -99,19 +97,14 @@ public class ButlerItem extends VersionedItem implements UpdateHandler
                 return;
             }
             LOG.info("Downloading new Butler version...");
-            try
+            try(Response res = Bot.httpClient.newCall(new Request.Builder().url(bot.getLink()).get().build()).execute())
             {
-                Response res = Bot.httpClient.newCall(new Request.Builder().url(bot.getLink()).get().build()).execute();
                 if(!res.isSuccessful())
                 {
-                    res.close();
                     LOG.warn("OkHttp returned failure for {}", bot.getLink());
                     return;
                 }
-                try(ResponseBody body = res.body())
-                {
-                    Files.copy(body.byteStream(), UPDATE_FILE, StandardCopyOption.REPLACE_EXISTING);
-                }
+                Files.copy(res.body().byteStream(), UPDATE_FILE, StandardCopyOption.REPLACE_EXISTING);
             }
             catch(Exception e)
             {

--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/items/JDActionItem.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/items/JDActionItem.java
@@ -72,6 +72,8 @@ public class JDActionItem extends VersionedItem
 
             if(!res.isSuccessful() || body == null)
             {
+                if(body != null)
+                    body.close();
                 VersionChecker.LOG.warn("Http call to JDAction repo failed");
                 return null;
             }
@@ -79,6 +81,7 @@ public class JDActionItem extends VersionedItem
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 
             Document doc = dBuilder.parse(body.byteStream());
+            body.close();
 
             Element root = doc.getDocumentElement();
             root.normalize();

--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/items/JDActionItem.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/items/JDActionItem.java
@@ -5,7 +5,6 @@ import com.kantenkugel.discordbot.versioncheck.RepoType;
 import com.kantenkugel.discordbot.versioncheck.VersionChecker;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
@@ -64,24 +63,18 @@ public class JDActionItem extends VersionedItem
     private String getCustomVersion()
     {
         Request req = new Request.Builder().get().url(versionDir).build();
-        try
+        try(Response res = Bot.httpClient.newCall(req).execute())
         {
-            Response res = Bot.httpClient.newCall(req).execute();
 
-            ResponseBody body = res.body();
-
-            if(!res.isSuccessful() || body == null)
+            if(!res.isSuccessful())
             {
-                if(body != null)
-                    body.close();
                 VersionChecker.LOG.warn("Http call to JDAction repo failed");
                 return null;
             }
 
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 
-            Document doc = dBuilder.parse(body.byteStream());
-            body.close();
+            Document doc = dBuilder.parse(res.body().byteStream());
 
             Element root = doc.getDocumentElement();
             root.normalize();


### PR DESCRIPTION
Butler will now properly close all RequestBodies (by wrapping the corresponding Response into a try-with-resources block).

Previously, in case of `!response.isSuccessful()`, we just returned, never closing the body.