### PR TITLE
Fix jdoc parsing for j11

### DIFF
--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/DocsCommand.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/DocsCommand.java
@@ -32,12 +32,13 @@ public class DocsCommand extends ReactionCommand
     {
         EmbedBuilder embed = getDefaultEmbed()
                 .setTitle(documentation.getTitle(), documentation.getUrl(jDocBase));
-        if(documentation.getFields() != null && documentation.getFields().get("Deprecated:") != null)
+        Map<String, List<String>> fields = documentation.getFields();
+        if(fields != null && fields.get("Deprecated:") != null)
         {
             //element deprecated
             embed.setColor(Color.RED);
         }
-        else if(documentation.getFields() != null && documentation.getFields().get("Incubating") != null)
+        else if(fields != null && fields.get("Incubating") != null)
         {
             //incubating
             embed.setColor(Color.orange);
@@ -55,9 +56,9 @@ public class DocsCommand extends ReactionCommand
         {
             embed.appendDescription(documentation.getContent());
         }
-        if (documentation.getFields() != null && documentation.getFields().size() > 0)
+        if (fields != null && fields.size() > 0)
         {
-            for (Map.Entry<String, List<String>> field : documentation.getFields().entrySet())
+            for (Map.Entry<String, List<String>> field : fields.entrySet())
             {
                 String fieldValue = String.join("\n", field.getValue());
                 if (fieldValue.length() > MessageEmbed.VALUE_MAX_LENGTH)

--- a/bot/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocParser.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocParser.java
@@ -136,7 +136,7 @@ public class JDocParser {
             final Element details = document.getElementsByClass("details").first();
             if(details != null) {
                 //methods
-                Element tmp = getSingleElementByQuery(details, "a[name=\"method.detail\"]");
+                Element tmp = getSingleElementByQuery(details, "a[name=\"method.detail\"], a[id=\"method.detail\"]");
                 List<DocBlock> docBlock = getDocBlock(jdocBase, tmp, classDoc);
                 if(docBlock != null) {
                     for(DocBlock block : docBlock) {
@@ -145,7 +145,7 @@ public class JDocParser {
                     }
                 }
                 //vars
-                tmp = getSingleElementByQuery(details, "a[name=\"field.detail\"]");
+                tmp = getSingleElementByQuery(details, "a[name=\"field.detail\"], a[id=\"field.detail\"]");
                 docBlock = getDocBlock(jdocBase, tmp, classDoc);
                 if(docBlock != null) {
                     for(DocBlock block : docBlock) {
@@ -153,7 +153,7 @@ public class JDocParser {
                     }
                 }
                 //enum-values
-                tmp = getSingleElementByQuery(details, "a[name=\"enum.constant.detail\"]");
+                tmp = getSingleElementByQuery(details, "a[name=\"enum.constant.detail\"], a[id=\"enum.constant.detail\"]");
                 docBlock = getDocBlock(jdocBase, tmp, classDoc);
                 if(docBlock != null) {
                     for(DocBlock block : docBlock) {
@@ -238,18 +238,22 @@ public class JDocParser {
             String hashLink = null;
             for(elem = elem.nextElementSibling(); elem != null; elem = elem.nextElementSibling()) {
                 if(elem.tagName().equals("a")) {
-                    hashLink = '#' + elem.attr("name");
+                    hashLink = '#' + (elem.id().isEmpty() ? elem.attr("name") : elem.id());
                 } else if(elem.tagName().equals("ul")) {
                     Element tmp = elem.getElementsByTag("h4").first();
                     String title = JDocUtil.fixSpaces(tmp.text().trim());
                     String description = "", signature = "";
                     OrderedMap<String, List<String>> fields = new ListOrderedMap<>();
-                    for(;tmp != null; tmp = tmp.nextElementSibling()) {
+                    for(tmp = tmp.nextElementSibling();tmp != null; tmp = tmp.nextElementSibling()) {
                         if(tmp.tagName().equals("pre")) {
                             //contains full signature
                             signature = JDocUtil.fixSpaces(tmp.text().trim());
+                        } else if(tmp.tagName().equals("div") && tmp.className().equals("deprecationBlock")) {
+                            //deprecation block(jdk11)
+                            Element deprecationElem = tmp.getElementsByClass("deprecationComment").first();
+                            fields.put("Deprecated:", Collections.singletonList(JDocUtil.formatText(deprecationElem.html(), baseLink)));
                         } else if(tmp.tagName().equals("div") && tmp.className().equals("block")) {
-                            //main block of content (description or deprecation)
+                            //main block of content (description or deprecation (prej11))
                             Element deprecationElem = tmp.getElementsByClass("deprecationComment").first();
                             if(deprecationElem != null) {
                                 //deprecation block

--- a/bot/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocUtil.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/jdocparser/JDocUtil.java
@@ -90,7 +90,7 @@ public class JDocUtil {
                     '[' +
                     fixSignature(matcher.group(4).replace("*", "")) +
                     ']' +
-                    '(' + resolveLink(matcher.group(2), currentUrl) + ')' +
+                    '(' + resolveLink(matcher.group(2), currentUrl).replace(")", "%29") + ')' +
                     ((!matcher.group(1).isEmpty() || !matcher.group(3).isEmpty()) ? "***" : "")
             );
         }


### PR DESCRIPTION
This fixes multiple issues that arise from parsing the jdocs that are generated from our CI (which now runs on JDK11).

This includes
- Deprecation block having different className now
- All the jump links using ids instead of name now
- Hashes for jump-links being able to contain (closing) parenthesis now, which is not supported by markdown

To keep the JDocParser working with jdocs generated with earlier JDK versions, the old behavior is being handled as well.

Additionally, there were some minor performance tweaks
