### PR TITLE
Implementation of a Command printing the release time of a build

### DIFF
--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
@@ -31,6 +31,7 @@ public class Dispatcher extends ListenerAdapter
     {
         this.registerCommand(new BuildGradleCommand());
         this.registerCommand(new ChangelogCommand());
+        this.registerCommand(new DateVersionCommand());
         this.registerCommand(new DocsCommand(this.reactListReg));
         this.registerCommand(new EvalCommand());
         this.registerCommand(new GradleCommand());

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/ChangelogCommand.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/ChangelogCommand.java
@@ -1,9 +1,14 @@
 package com.almightyalpaca.discord.jdabutler.commands.commands;
 
+import com.almightyalpaca.discord.jdabutler.Bot;
 import com.almightyalpaca.discord.jdabutler.commands.Command;
+import com.almightyalpaca.discord.jdabutler.util.DateUtils;
 import com.almightyalpaca.discord.jdabutler.util.EmbedUtil;
+import com.kantenkugel.discordbot.jenkinsutil.JenkinsApi;
+import com.kantenkugel.discordbot.jenkinsutil.JenkinsBuild;
 import com.kantenkugel.discordbot.versioncheck.VersionCheckerRegistry;
 import com.kantenkugel.discordbot.versioncheck.changelog.ChangelogProvider;
+import com.kantenkugel.discordbot.versioncheck.changelog.JenkinsChangelogProvider;
 import com.kantenkugel.discordbot.versioncheck.items.VersionedItem;
 import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -13,12 +18,17 @@ import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public class ChangelogCommand extends Command
 {
 
     private static final String[] ALIASES = { "changes" };
+    private static final JenkinsApi JENKINS = DateUtils.JENKINS;
+    private static final DateTimeFormatter FORMATTER = DateUtils.getDateTimeFormatter();
 
     @Override
     public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
@@ -67,11 +77,33 @@ public class ChangelogCommand extends Command
                 reply(event, "The specified version does not exist");
                 return;
             }
+
+            // Get time of build
+            String publishedTime;
+            try
+            {
+                final JenkinsBuild build = args == null
+                        ? JENKINS.getLastSuccessfulBuild()
+                        : JENKINS.getBuild(Integer.parseInt(args[0]));
+
+                final OffsetDateTime buildTime = build.buildTime;
+                publishedTime = FORMATTER.format(buildTime);
+            }
+            catch (NumberFormatException | IOException ex)
+            {
+                Bot.LOG.error("Exception in ChangelogCommand occured!", ex);
+                publishedTime = "Unable to get Release Time";
+            }
+
+            String title;
             if(changelog.getChangelogUrl() == null)
-                eb.appendDescription("**").appendDescription(changelog.getTitle()).appendDescription("**:\n");
+                title = String.format("**%s**", changelog.getTitle());
             else
-                eb.appendDescription("[").appendDescription(changelog.getTitle()).appendDescription("](")
-                        .appendDescription(changelog.getChangelogUrl()).appendDescription("):\n");
+                title = String.format("[%s](%s)", changelog.getTitle(), changelog.getChangelogUrl());
+
+            final String versionTitle = String.format("%s *(%s)*:\n", title, publishedTime);
+            eb.appendDescription(versionTitle);
+
             if(changelog.getChangeset().isEmpty())
                 eb.appendDescription("No changes available for this version");
             else
@@ -80,13 +112,19 @@ public class ChangelogCommand extends Command
         //more than 1 version given
         else
         {
-            List<ChangelogProvider.Changelog> changelogs = clProvider.getChangelogs(args[versionStart], args[versionStart + 1]);
+            final String startVersion = args[versionStart];
+            final String endVersion = args[versionStart + 1];
+
+            // get and increment build number instead of fetching it from every changelog to be more reliable
+            final int start = JenkinsChangelogProvider.extractBuild(startVersion);
+            List<ChangelogProvider.Changelog> changelogs = clProvider.getChangelogs(startVersion, endVersion);
             if(changelogs.size() == 0)
             {
                 reply(event, "No Changelogs found in given range");
                 return;
             }
             int fields = 0;
+            int buildNr = start;
             for(ChangelogProvider.Changelog changelog : changelogs) {
                 String body = String.join("\n", changelog.getChangeset());
                 if(body.length() > MessageEmbed.VALUE_MAX_LENGTH)
@@ -97,13 +135,27 @@ public class ChangelogCommand extends Command
                         body = "[Link]("+changelog.getChangelogUrl()+") Too large to show.";
                 }
 
-                eb.addField(changelog.getTitle(), body, false);
+                // Get time of build
+                String publishedTime;
+                try
+                {
+                    final JenkinsBuild build = JENKINS.getBuild(buildNr);
+                    final OffsetDateTime buildTime = build.buildTime;
+                    publishedTime = FORMATTER.format(buildTime);
+                }
+                catch (IOException ex)
+                {
+                    Bot.LOG.error("Exception in ChangelogCommand occured!", ex);
+                    publishedTime = "Unable to get Release Time";
+                }
+                eb.addField(String.format("%s (%s)", changelog.getTitle(), publishedTime), body, false);
 
                 if(++fields == 19 && changelogs.size() > 20)
                 {
                     eb.addField("...", "Embed limit reached. See [Online changelog]("
                             + clProvider.getChangelogUrl() + ')', false);
                 }
+                buildNr++;
             }
         }
 
@@ -135,4 +187,5 @@ public class ChangelogCommand extends Command
     {
         return "changelog";
     }
+
 }

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/DateVersionCommand.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/DateVersionCommand.java
@@ -1,0 +1,124 @@
+package com.almightyalpaca.discord.jdabutler.commands.commands;
+
+import com.almightyalpaca.discord.jdabutler.Bot;
+import com.almightyalpaca.discord.jdabutler.commands.Command;
+import com.almightyalpaca.discord.jdabutler.util.EmbedUtil;
+import com.kantenkugel.discordbot.jenkinsutil.JenkinsApi;
+import com.kantenkugel.discordbot.jenkinsutil.JenkinsBuild;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+
+import java.awt.Color;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+public class DateVersionCommand extends Command
+{
+    private static final String DATE_FORMAT = "yyyy-MM-dd; HH:mm:ss";
+    private static final String[] ALIASES = { "date", "published" };
+    private static final JenkinsApi JENKINS = JenkinsApi.JDA_JENKINS;
+    private static final Calendar CAL = Calendar.getInstance();
+    private static final DateFormat DFM = getDateFormat();
+
+    private static DateFormat getDateFormat() {
+        DateFormat dfm;
+        try
+        {
+            dfm = new SimpleDateFormat(DATE_FORMAT);
+        }
+        catch (NullPointerException | IllegalArgumentException ex)
+        {
+            final String defaultFormat = "dd.MM.yyyy; HH:mm:ss";
+            Bot.LOG.warn("Given format for DateVersionCommand was not valid, using: " + defaultFormat);
+            dfm = new SimpleDateFormat(defaultFormat);
+        }
+        return dfm;
+    }
+
+    @Override
+    public void dispatch(final User sender, final TextChannel channel, final Message message, final String content, final GuildMessageReceivedEvent event)
+    {
+        final EmbedBuilder eb = new EmbedBuilder();
+
+        JenkinsBuild build;
+        try
+        {
+            if (content.trim().isEmpty())
+                build = JENKINS.getLastSuccessfulBuild();
+            else
+            {
+                String buildNrStr = content;
+
+                final int underscoreIndex = content.indexOf('_');  // in case somebody provided a full version (e. g. 3.8.3_463)
+                if (underscoreIndex != -1)
+                    buildNrStr = content.substring(underscoreIndex + 1);
+
+                final int buildNr = Integer.parseInt(buildNrStr.trim());
+                build = JENKINS.getBuild(buildNr);
+            }
+        }
+        catch (IOException | NumberFormatException ex)
+        {
+            String title;
+            if (ex instanceof IOException)
+                title = "Connection to the Jenkins Server timed out!";
+            else if (ex instanceof NumberFormatException)
+                title = "Given input was not a valid build number!";
+            else
+                title = "Unknown Error occured!";
+
+            final MessageEmbed failureEmbed = eb.setAuthor("Error occured!", null, EmbedUtil.getJDAIconUrl())
+                    .setTitle(title, null)
+                    .setColor(Color.RED)
+                    .build();
+            reply(event, failureEmbed);
+            return;
+        }
+
+        // Get time of build
+        final long buildTime = build.buildTime.toInstant().toEpochMilli();
+
+        CAL.setTimeInMillis(buildTime);
+        final String publishedTime = DFM.format(CAL.getTime());
+
+        // Get correct version (copied from JenkinsChangelogProvider#getChangelogs(String, String))
+        final String buildVersion = build.status == JenkinsBuild.Status.SUCCESS
+                ? build.artifacts.values().iterator().next().fileNameParts.get(1)
+                : build.buildNum + " (failed)";
+
+        // Return Info to User
+        EmbedUtil.setColor(eb);
+
+        final MessageEmbed successEmbed = eb.setAuthor("Release Time of Version " + buildVersion, build.getUrl(), EmbedUtil.getJDAIconUrl())
+            .setTitle(publishedTime, null)
+            .build();
+
+        reply(event, successEmbed);
+    }
+
+    @Override
+    public String[] getAliases()
+    {
+        return DateVersionCommand.ALIASES;
+    }
+
+    @Override
+    public String getHelp()
+    {
+        return "Prints the datetime when the given build number or the latest build was published";
+    }
+
+    @Override
+    public String getName()
+    {
+        return "date";
+    }
+
+}

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/DateVersionCommand.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/DateVersionCommand.java
@@ -17,9 +17,6 @@ import java.awt.Color;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class DateVersionCommand extends Command
 {
@@ -65,8 +62,7 @@ public class DateVersionCommand extends Command
         }
         catch (IOException | NumberFormatException ex)
         {
-            final String fullStackTrace = getFullStackTrace(ex);
-            Bot.LOG.error("Exception in DateVersionCommand occured!" + System.lineSeparator() + fullStackTrace);
+            Bot.LOG.error("Exception in DateVersionCommand occured!", ex);
 
             String title;
             if (ex instanceof IOException)
@@ -102,15 +98,6 @@ public class DateVersionCommand extends Command
             .build();
 
         reply(event, successEmbed);
-    }
-
-    private String getFullStackTrace(Exception ex) {
-        List<StackTraceElement> stackTraceElements = Arrays.asList(ex.getStackTrace());
-        String stacktrace = stackTraceElements.stream().map(entry -> "\tat " + entry.toString()).collect(Collectors.joining(System.lineSeparator()));
-
-        StringBuilder builder = new StringBuilder(String.format("%s: %s" + System.lineSeparator(), ex.getClass().getName(), ex.getMessage()));
-        builder.append(stacktrace);
-        return builder.toString();
     }
 
     @Override

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/DateUtils.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/DateUtils.java
@@ -1,0 +1,34 @@
+package com.almightyalpaca.discord.jdabutler.util;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import com.almightyalpaca.discord.jdabutler.Bot;
+import com.kantenkugel.discordbot.jenkinsutil.JenkinsApi;
+
+public final class DateUtils
+{
+    private static final String DATE_FORMAT = "dd/MM/yyyy 'at' HH:mm:ss";
+    public static final JenkinsApi JENKINS = JenkinsApi.JDA_JENKINS;
+    public static final DateTimeFormatter FORMATTER = getDateTimeFormatter();
+
+    public static DateTimeFormatter getDateTimeFormatter() {
+        DateTimeFormatter formatter;
+        try
+        {
+            formatter = DateTimeFormatter.ofPattern(DATE_FORMAT + " (z)");
+        }
+        catch (NullPointerException | IllegalArgumentException ex)
+        {
+            final String defaultFormat = "dd.MM.yyyy 'at' HH:mm:ss (z)";
+            Bot.LOG.warn("Given format for DateVersionCommand was not valid, using: " + defaultFormat);
+            formatter = DateTimeFormatter.ofPattern(defaultFormat);
+        }
+
+        return formatter.withZone(ZoneId.of("UTC"));
+    }
+
+    // prevent instantiation
+    private DateUtils() {}
+
+}

--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/changelog/JenkinsChangelogProvider.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/changelog/JenkinsChangelogProvider.java
@@ -128,7 +128,8 @@ public class JenkinsChangelogProvider implements ChangelogProvider
         return fields;
     }
 
-    private static int extractBuild(String version)
+    // public since also accessed in the ChangelogCommand class
+    public static int extractBuild(String version)
     {
         int i = version.lastIndexOf('_');
         try


### PR DESCRIPTION
## Description

This PR adds a **command telling when a JDA build was released**.

If **no version** was provided, the **latest successful build** will be used instead.

**Potential Errors** like parsing the User Input and `IOException` of `JenkinsApi#getBuild` **are correctly handled**.

Used **Code Style was respected**.

## Example Preview
![Example Preview](http://puu.sh/DLe4z/39049cdfdd.png)