### PR TITLE
Remove Version-Tracking for JDA4-Beta

### DIFF
--- a/bot/src/main/java/com/kantenkugel/discordbot/jenkinsutil/JenkinsApi.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/jenkinsutil/JenkinsApi.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 public class JenkinsApi
 {
     public static final String JDA_JENKINS_BASE = "https://ci.dv8tion.net";
-    public static final JenkinsApi JDA4_JENKINS = JenkinsApi.forConfig(JDA_JENKINS_BASE, "JDA4-Beta");
     public static final JenkinsApi JDA_JENKINS = JenkinsApi.forConfig(JDA_JENKINS_BASE, "JDA");
 
     /**

--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
@@ -1,6 +1,5 @@
 package com.kantenkugel.discordbot.versioncheck;
 
-import com.kantenkugel.discordbot.jenkinsutil.JenkinsApi;
 import com.kantenkugel.discordbot.versioncheck.items.*;
 
 import java.util.*;
@@ -102,12 +101,6 @@ public class VersionCheckerRegistry
          */
         //JDA
         addItem(new JDAItem());
-        addItem(new JDAItem(
-                JenkinsApi.JDA4_JENKINS,
-                544915548366962688L, // @JDA 4 Updates
-                289742061220134912L, // #experimental
-                "JDA4-Beta")         // JDA4-Beta job
-        );
         //Lavaplayer
         addItem(new SimpleVersionedItem("Lavaplayer", RepoType.JCENTER, DependencyType.DEFAULT, "com.sedmelluq", "lavaplayer")
                 .setUrl("https://github.com/sedmelluq/lavaplayer#lavaplayer---audio-player-library-for-discord")


### PR DESCRIPTION
Since the JDA4-Beta CI build will be renamed to JDA (and the old one being archived), the version-tracking for JDA4-Beta is no longer needed and can be removed.

This PR will be merged when it is clear that the JDA4-Beta branch will no longer receive updates until its rename (JDA4 Release)