### PR TITLE
Improve the !pom.xml template

### DIFF
--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/RepoType.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/RepoType.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public enum RepoType
 {
-    JCENTER("http://jcenter.bintray.com/", Pair.of("jcenter()", null), "bintray"),
+    JCENTER("https://jcenter.bintray.com/", Pair.of("jcenter()", null), "bintray"),
     MAVENCENTRAL("https://repo.maven.apache.org/maven2/", null, "central", "maven");
 
 

--- a/bot/src/main/resources/maven.pom
+++ b/bot/src/main/resources/maven.pom
@@ -8,6 +8,11 @@
     <artifactId>example-bot</artifactId>
     <version>1.0</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
 %s
 
 %s

--- a/bot/src/main/resources/maven.pom
+++ b/bot/src/main/resources/maven.pom
@@ -26,7 +26,6 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
@@ -35,7 +34,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.1</version>
                 <configuration>

--- a/bot/src/main/resources/maven.pom
+++ b/bot/src/main/resources/maven.pom
@@ -35,25 +35,25 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>YourMainClass</mainClass> <!-- You have to replace this with a path to your main class like my.path.Main -->
+                        </transformer>
+                    </transformers>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>YourMainClass</mainClass> <!-- You have to replace this with a path to your main class like my.path.Main -->
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bot/src/main/resources/maven.pom
+++ b/bot/src/main/resources/maven.pom
@@ -13,17 +13,6 @@
 %s
 
     <build>
-        <sourceDirectory>src/main/java</sourceDirectory>
-        <resources>
-            <resource>
-                <targetPath>.</targetPath>
-                <filtering>true</filtering>
-                <directory>${basedir}/src/main/resources/</directory>
-                <includes>
-                    <include>*</include>
-                </includes>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Fix a bunch of issues with the `!pom.xml` template POM:
* Specify the encoding,
* Use the `shade` plugin instead of the `assembly` one,
* Remove unnecessary `groupId` declarations for plugins,
* Remove the unnecessary `sourceDirectory` declaration and
* Remove the unnecessary `resources` declaration