### PR TITLE
Update JDA, maven, gradle

### DIFF
--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -12,50 +12,50 @@ repositories {
 
 dependencies {
     // JDA
-    compile ('net.dv8tion:JDA:4.2.0_171') {
+    implementation ('net.dv8tion:JDA:4.2.0_171') {
         exclude module: 'opus-java'
     }
     
     // Trove Collections
-    compile group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
+    implementation group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
     
     // Other Collections
-    compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.1'
+    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.1'
 
     // Webhooks
-    compile group: 'club.minnced', name: 'discord-webhooks', version: '0.1.3'
+    implementation group: 'club.minnced', name: 'discord-webhooks', version: '0.1.3'
 
     // Apache commons Lang 3
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
 
     // Apache Commons Text
-    compile group: 'org.apache.commons', name: 'commons-text', version: '1.2'
+    implementation group: 'org.apache.commons', name: 'commons-text', version: '1.2'
 
     // Apache Commons IO
-    compile group: 'commons-io', name: 'commons-io', version: '2.6'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.6'
 
     // Groovy JSR-223 / Script engine. TODO: might change eval command to jshell in the future
-    compile group: 'org.codehaus.groovy', name: 'groovy-jsr223', version: '2.5.3'
+    implementation group: 'org.codehaus.groovy', name: 'groovy-jsr223', version: '2.5.3'
 
     // Gson
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
 
     // Guava
-    compile group: 'com.google.guava', name: 'guava', version: '24.0-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '24.0-jre'
 
     // Dropbox
-    compile group: 'com.dropbox.core', name: 'dropbox-core-sdk', version: '3.0.6'
+    implementation group: 'com.dropbox.core', name: 'dropbox-core-sdk', version: '3.0.6'
 
     // Zip4J
-    compile group: 'net.lingala.zip4j', name: 'zip4j', version: '1.3.2'
+    implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '1.3.2'
 
     // jsoup HTML parser library @ http://jsoup.org/
-    compile group: 'org.jsoup', name: 'jsoup', version: '1.11.2'
+    implementation group: 'org.jsoup', name: 'jsoup', version: '1.11.2'
     
     // Remark for html -> markdown (docs)
-    compile "com.kotcrab.remark:remark:1.0.0"
+    implementation "com.kotcrab.remark:remark:1.0.0"
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }
 
 run {

--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // JDA
-    compile ('net.dv8tion:JDA:4.1.0_95') {
+    compile ('net.dv8tion:JDA:4.2.0_171') {
         exclude module: 'opus-java'
     }
     

--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // JDA
-    implementation ('net.dv8tion:JDA:4.2.0_171') {
+    implementation ('net.dv8tion:JDA:4.2.0_191') {
         exclude module: 'opus-java'
     }
     

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/ChangelogCommand.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/ChangelogCommand.java
@@ -108,7 +108,7 @@ public class ChangelogCommand extends Command
         }
 
         MessageEmbed embed = eb.build();
-        if(embed.isSendable(AccountType.BOT))
+        if(embed.isSendable())
         {
             reply(event, embed);
         }

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/moderation/SoftbanCommand.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/moderation/SoftbanCommand.java
@@ -36,6 +36,7 @@ public class SoftbanCommand extends Command
         final Guild guild = event.getGuild();
         final Member self = guild.getSelfMember();
 
+        final String reason = "Softban by " + sender.getName();
         for (final User user : mentions)
         {
             if (user == null)
@@ -43,16 +44,17 @@ public class SoftbanCommand extends Command
             final Member member = guild.getMember(user);
             if (member != null && !self.canInteract(member))
                 continue;
-            final String reason = "Softban by " + sender.getName();
-            guild.ban(user, 7).reason(reason).queue((v) -> guild.unban(user).reason(reason).queue());
+
+            guild.ban(user, 7).reason(reason)
+                 .flatMap((v) -> guild.unban(user).reason(reason))
+                 .queue();
         }
     }
 
     @Override
     public String[] getAliases()
     {
-        return new String[]
-        { "sb" };
+        return new String[] { "sb" };
     }
 
     @Override

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/gradle/GradleDownloader.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/gradle/GradleDownloader.java
@@ -15,7 +15,7 @@ public class GradleDownloader
 {
     public static final File GRADLE_DIR = new File("gradle-cache/");
 
-    public static final String GRADLE_VERSION = "4.10.2";
+    public static final String GRADLE_VERSION = "6.5";
 
     public static final File GRADLE_ZIP = new File(GradleDownloader.GRADLE_DIR, "gradle-" + GradleDownloader.GRADLE_VERSION + "-bin.zip");
 

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/gradle/GradleUtil.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/gradle/GradleUtil.java
@@ -41,10 +41,10 @@ public class GradleUtil
     public static String getDependencyString(final VersionedItem item, final boolean pretty)
     {
         if (pretty)
-            return String.format("compile group: '%s', name: '%s', version: '%s'",
+            return String.format("implementation group: '%s', name: '%s', version: '%s'",
                     item.getGroupId(), item.getArtifactId(), item.getVersion());
         else
-            return String.format("compile '%s:%s:%s'", item.getGroupId(), item.getArtifactId(), item.getVersion());
+            return String.format("implementation '%s:%s:%s'", item.getGroupId(), item.getArtifactId(), item.getVersion());
     }
 
     public static String getPluginsBlock(final Collection<Pair<String, String>> plugins)

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/gradle/GradleUtil.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/gradle/GradleUtil.java
@@ -14,7 +14,7 @@ public class GradleUtil
 
     public static final Collection<Pair<String, String>> DEFAULT_PLUGINS = Arrays.asList(new ImmutablePair<>("java", null), new ImmutablePair<>("application", null), new ImmutablePair<>("com.github.johnrengelman.shadow", GradleUtil.SHADOW_VERSION));
 
-    public static final String SHADOW_VERSION = "4.0.4";
+    public static final String SHADOW_VERSION = "6.0.0";
 
     public static String getBuildFile(final Collection<Pair<String, String>> plugins, final String mainClassName, final String version, final String sourceCompatibility, final List<VersionedItem> items, final boolean pretty)
     {

--- a/bot/src/main/resources/maven.pom
+++ b/bot/src/main/resources/maven.pom
@@ -21,7 +21,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -29,7 +29,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.4</version>
                 <configuration>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'idea'
     id 'com.github.ben-manes.versions' version '0.20.0'
-    id 'com.github.johnrengelman.shadow' version '4.0.2' apply false
+    id 'com.github.johnrengelman.shadow' version '6.0.0' apply false
 }
 
 allprojects {
@@ -26,7 +26,7 @@ subprojects {
     compileJava.options.encoding = 'UTF-8'
 
     shadowJar { task ->
-        baseName = task.project.name.capitalize()
+        archiveBaseName = task.project.name.capitalize()
     }
 
     repositories {
@@ -34,11 +34,11 @@ subprojects {
     }
 
     dependencies {
-        compile 'org.slf4j:slf4j-api:1.7.25'
-        compile 'ch.qos.logback:logback-classic:1.2.3'
+        implementation 'org.slf4j:slf4j-api:1.7.25'
+        implementation 'ch.qos.logback:logback-classic:1.2.3'
     }
 }
 
-project(':bot') {
+project(':launcher') {
     tasks.run.enabled = false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates a lot of dependencies and build-tool related plugins
- JDA updated to current version (4.2.0_191)
- gradle globally changed to 6.5
  - includes gradleproject zip
  - shadow plugin bumped to 6.0.0
  - switched from compile configurations to implementation
- maven plugins for pom.xml command updated
  - compiler plugin bumped to 3.8.1
  - shadow plugin bumped to 3.2.4

Closes #62