### PR TITLE
Update lavaplayer artifact details in the version registry

### DIFF
--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/RepoType.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/RepoType.java
@@ -9,6 +9,7 @@ import java.util.List;
 public enum RepoType
 {
     JCENTER("https://jcenter.bintray.com/", Pair.of("jcenter()", null), "bintray"),
+    JITPACK("https://jitpack.io/", Pair.of("maven { url \"https://jitpack.io/\" }", null), "jitpack"),
     MAVENCENTRAL("https://repo.maven.apache.org/maven2/", null, "central", "maven");
 
 

--- a/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
+++ b/bot/src/main/java/com/kantenkugel/discordbot/versioncheck/VersionCheckerRegistry.java
@@ -102,7 +102,7 @@ public class VersionCheckerRegistry
         //JDA
         addItem(new JDAItem());
         //Lavaplayer
-        addItem(new SimpleVersionedItem("Lavaplayer", RepoType.JCENTER, DependencyType.DEFAULT, "com.sedmelluq", "lavaplayer")
+        addItem(new SimpleVersionedItem("Lavaplayer", RepoType.JITPACK, DependencyType.DEFAULT, "com.github.devoxin", "lavaplayer")
                 .setUrl("https://github.com/sedmelluq/lavaplayer#lavaplayer---audio-player-library-for-discord")
                 .setAliases("lava", "player")
                 .setAnnouncementRoleId(241948768113524762L)     //Lavaplayer Updates


### PR DESCRIPTION
The Lavaplayer item in VersionCheckerRegistry now points to devoxin's temporary upstream. I haven't been able to check if this patch actually works (my deepest apologies if it doesn't), since I'm not sure I know how to properly launch the bot.