### PR TITLE
Changed the hastebin server to hastebin.de

### DIFF
--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/MiscUtils.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 public class MiscUtils
 {
-    private static String HASTEBIN_SERVER = "https://hastebin.com/"; //requires trailing slash
+    private static String HASTEBIN_SERVER = "https://hastebin.de/"; //requires trailing slash
 
     public static ThreadFactory newThreadFactory(String threadName)
     {


### PR DESCRIPTION
This pull fixes the '!pom.xml' command which uses the now non functioning website 'hastebin.com', it is replaced by hastebin.de which is functional.