### PR TITLE
Add a `format` command

### DIFF
--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     
     // Remark for html -> markdown (docs)
     implementation "com.kotcrab.remark:remark:1.2.0"
+    
+    // palantir-java-format for java formatting
+    implementation "com.palantir.javaformat:palantir-java-format:2.2.0"
 
     testImplementation 'junit:junit:4.13.2'
 }

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/Dispatcher.java
@@ -54,6 +54,7 @@ public class Dispatcher extends ListenerAdapter
         this.registerCommand(new SoftbanCommand());
         this.registerCommand(new SlowmodeCommand());
         this.registerCommand(new UpdateCommand());
+        this.registerCommand(new FormatCommand(buttonListener));
     }
 
     public Set<Command> getCommands()

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/FormatCommand.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/commands/commands/FormatCommand.java
@@ -1,0 +1,217 @@
+package com.almightyalpaca.discord.jdabutler.commands.commands;
+
+import club.minnced.discord.webhook.external.JDAWebhookClient;
+import club.minnced.discord.webhook.send.WebhookMessage;
+import club.minnced.discord.webhook.send.WebhookMessageBuilder;
+import com.almightyalpaca.discord.jdabutler.Bot;
+import com.almightyalpaca.discord.jdabutler.commands.ButtonListener;
+import com.almightyalpaca.discord.jdabutler.commands.Command;
+import com.almightyalpaca.discord.jdabutler.util.CodeFormatter;
+import com.palantir.javaformat.java.FormatterException;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.exceptions.ErrorHandler;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.Button;
+import net.dv8tion.jda.api.interactions.components.ButtonInteraction;
+import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.internal.requests.CompletedRestAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class FormatCommand extends Command {
+	public FormatCommand(ButtonListener buttonListener) {
+		buttonListener.addListener("format", event -> {
+			if (event.getComponentId().startsWith("format")) {
+				final String[] args = event.getComponentId().split("\\|");
+				if (args[1].equals("accept")) {
+					String codeAuthorId = args[2];
+					String msgId = args[3];
+					
+					if (!event.getUser().getId().equals(codeAuthorId)) { //Only accept code author clicks
+						event.deferEdit().queue();
+						return;
+					}
+					
+					formatById(event.getTextChannel(), event, msgId);
+				}
+				
+				//Message is not ephemeral.
+				Objects.requireNonNull(event.getMessage(), "Message should not be ephemeral")
+						.delete()
+						.queue(null, new ErrorHandler().ignore(ErrorResponse.UNKNOWN_MESSAGE));
+			}
+		});
+	}
+
+	@Override
+	public void dispatch(final User sender, final TextChannel channel, final Message eventMessage, final String content, final GuildMessageReceivedEvent event) {
+		try {
+			final long msgId = Long.parseLong(content);
+
+			channel.retrieveMessageById(msgId).queue(m -> {
+				if (m.getAuthor().isBot()) {
+					event.getChannel().sendMessage("Can't format bot messages :angry:").queue();
+					
+					return;
+				}
+				
+				final MessageBuilder messageBuilder = new MessageBuilder();
+				final EmbedBuilder embedBuilder = new EmbedBuilder()
+						.setAuthor("Format request", null, event.getAuthor().getEffectiveAvatarUrl())
+						.addField("From", event.getAuthor().getAsMention(), true)
+						.addField("Target message", "[Message Link](" + m.getJumpUrl() + ")", true);
+				
+				messageBuilder
+						.setContent(m.getAuthor().getAsMention())
+						.setEmbeds(embedBuilder.build())
+						.setActionRows(ActionRow.of(
+								Button.danger("format|accept|" + m.getAuthor().getId() + "|" + msgId, "Accept"),
+								Button.secondary("format|reject" + msgId, "Reject")
+						));
+				
+				m.getChannel().sendMessage(messageBuilder.build())
+						.mentionUsers(m.getAuthor().getIdLong()) //Mention the target message author
+						.queue(ignored -> eventMessage.delete().queue());
+			});
+		} catch (NumberFormatException ignored) {
+			tryFormatMessage(eventMessage, content, event);
+		}
+	}
+
+	private void formatById(TextChannel channel, ButtonInteraction event, String msgId) {
+		channel.retrieveMessageById(msgId).queue(m -> inferContent(m, m.getContentRaw(), inferredContent -> {
+					try {
+						format(m.getTextChannel(), inferredContent.code, m.getAuthor().getIdLong(), m.getIdLong(), inferredContent.isFromFile);
+					} catch (FormatterException e) {
+						Bot.LOG.error("Error formatting java code", e);
+
+						event.reply(":x: Could not format your code :/").setEphemeral(true).queue();
+					}
+				}), new ErrorHandler()
+						.handle(ErrorResponse.UNKNOWN_MESSAGE, e -> event.reply("Invalid message ID").setEphemeral(true).queue())
+						.handle(t -> true,
+								t -> Bot.LOG.error("Error formatting java code (while retrieving message)", t))
+		);
+	}
+
+	private void tryFormatMessage(Message message, String content, GuildMessageReceivedEvent event) {
+		inferContent(message, content, inferredContent -> {
+			try {
+				format(event.getChannel(), inferredContent.code, event.getAuthor().getIdLong(), message.getIdLong(), inferredContent.isFromFile);
+			} catch (FormatterException e) {
+				Bot.LOG.error("Error formatting java code", e);
+				
+				event.getChannel().sendMessage(":x: Could not format your code :/").queue();
+			}
+		});
+	}
+
+	private void inferContent(Message message, String altContent, Consumer<InferredContent> callback) {
+		if (!message.getAttachments().isEmpty()) {
+			final Message.Attachment attachment = message.getAttachments().get(0);
+			if ("java".equals(attachment.getFileExtension())) {
+			    readAttachment(attachment, s -> callback.accept(new InferredContent(s, true)));
+
+				return;
+			}
+
+			if (!attachment.isVideo() && !attachment.isImage()) {
+                readAttachment(attachment, s -> callback.accept(new InferredContent(s, true)));
+                
+                return;
+			}
+		}
+
+        callback.accept(new InferredContent(altContent, false));
+	}
+
+	private void readAttachment(Message.Attachment attachment, Consumer<String> consumer) {
+		attachment.retrieveInputStream().thenAcceptAsync(input -> {
+			try (BufferedInputStream in = new BufferedInputStream(input)) {
+				consumer.accept(new String(in.readAllBytes()));
+			} catch (IOException e) {
+				Bot.LOG.error("Error reading attachment from {}", attachment.getProxyUrl(), e);
+			}
+		});
+	}
+
+	private void format(TextChannel channel, String content, long authorId, long codeMessageId, boolean fromFile) throws FormatterException {
+		final String code = CodeFormatter.format(content, fromFile); //Can potentially throw
+
+		final Guild guild = channel.getGuild();
+		final JDA jda = channel.getJDA();
+		guild.retrieveMemberById(authorId).queue(member -> {
+			final WebhookMessage webhookMessage = getWebhookMessage(code, member, fromFile);
+
+			channel.retrieveWebhooks().queue(webhooks -> {
+				final RestAction<Webhook> webhookGetter = retrieveFormatWebhook(channel, jda, webhooks);
+
+				webhookGetter.queue(webhook -> {
+					JDAWebhookClient.fromJDA(webhook).send(webhookMessage);
+					channel.deleteMessageById(codeMessageId).reason("Space freeing by format command").queue();
+				});
+			});
+		});
+	}
+
+	@NotNull
+	private RestAction<Webhook> retrieveFormatWebhook(TextChannel channel, JDA jda, List<Webhook> webhooks) {
+		final String expectedWebhookName = jda.getSelfUser().getAsTag() + "'s Format webhook";
+		final Optional<Webhook> optWebhook = webhooks.stream().filter(w -> w.getName().equals(expectedWebhookName)).findFirst();
+
+		if (optWebhook.isPresent()) {
+			return new CompletedRestAction<>(jda, optWebhook.get());
+		} else {
+			return channel.createWebhook(expectedWebhookName);
+		}
+	}
+
+	@NotNull
+	private WebhookMessage getWebhookMessage(String code, Member member, boolean fromFile) {
+		final boolean correctLength = code.length() <= Message.MAX_CONTENT_LENGTH;
+
+		final WebhookMessageBuilder messageBuilder = new WebhookMessageBuilder()
+				.setUsername(member.getEffectiveName())
+				.setAvatarUrl(member.getUser().getEffectiveAvatarUrl());
+
+		if (correctLength && !fromFile) {
+			messageBuilder.setContent(code);
+		} else {
+			messageBuilder.addFile("code.java", code.getBytes(StandardCharsets.UTF_8));
+		}
+
+		return messageBuilder.build();
+	}
+
+	@Override
+	public String getHelp() {
+		return "Formats your java code";
+	}
+
+	@Override
+	public String getName() {
+		return "format";
+	}
+
+	private static class InferredContent {
+		private final String code;
+		private final boolean isFromFile;
+
+		public InferredContent(String code, boolean isFromFile) {
+			this.code = code;
+			this.isFromFile = isFromFile;
+		}
+	}
+}

--- a/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/CodeFormatter.java
+++ b/bot/src/main/java/com/almightyalpaca/discord/jdabutler/util/CodeFormatter.java
@@ -1,0 +1,88 @@
+package com.almightyalpaca.discord.jdabutler.util;
+
+import com.palantir.javaformat.java.Formatter;
+import com.palantir.javaformat.java.FormatterException;
+import com.palantir.javaformat.java.JavaFormatterOptions;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class CodeFormatter {
+	private static final Pattern BLOCK_PATTERN = Pattern.compile("([\\s\\S]*)[`']{3}[a-zA-Z]*\\n([\\s\\S]*)\\n?[`']{3}([\\s\\S]*)");
+	
+	private static final Formatter FORMATTER = Formatter.createFormatter(JavaFormatterOptions.builder()
+			.style(JavaFormatterOptions.Style.PALANTIR)
+			.build());
+
+	public static String format(String code, boolean fromFile) throws FormatterException {
+		final Matcher matcher = BLOCK_PATTERN.matcher(code);
+		final boolean isCodeBlock = matcher.find();
+
+		final String prefix, suffix;
+		if (isCodeBlock) {
+			code = matcher.group(2).stripLeading();
+
+			if (fromFile) {
+				prefix = matcher.group(1).trim() + "\n\n";
+				suffix = matcher.group(3).trim() + "\n\n";
+			} else {
+				prefix = matcher.group(1).trim();
+				suffix = matcher.group(3).trim();
+			}
+		} else { //Replace potential lang at the start of the code
+			prefix = "";
+			code = code.trim();
+			if (code.startsWith("java")) {
+				code = code.substring(3);
+			}
+			suffix = "";
+		}
+
+		final String formattedCode = formatCode(code);
+		final String resultMsg;
+		if (fromFile) {
+			resultMsg = prefix + formattedCode + suffix;
+		} else {
+			resultMsg = String.format("%s```java\n%s```%s", prefix, formattedCode, suffix);
+		}
+
+		return resultMsg;
+	}
+
+	private static String formatCode(String code) throws FormatterException {
+		try { //Assume it's a complete file first
+			return FORMATTER.formatSource(code);
+		} catch (FormatterException e) { //Try formatting as partial code
+			final String prefix = "public class Test{void x(){"; //We need this otherwise the formatter dies
+			final String suffix = "}}";
+			final String classCode = prefix + code + suffix;
+
+			final String formattedCode = FORMATTER.formatSource(classCode);
+			final String formattedUserCode = formattedCode.lines()
+					.skip(2) //Skip class and method declaration
+					.limit(formattedCode.lines().count() - 4) //Skip class and method closing curly brackets
+					.collect(Collectors.joining("\n"));
+
+			int i = 0;
+			for (int userCodeLength = formattedUserCode.length(); i < userCodeLength; i++) {
+				if (!Character.isWhitespace(formattedUserCode.charAt(i))) {
+					break;
+				}
+			}
+
+			final int removedSpaces = i;
+			return formattedUserCode.lines()
+					//Remove the 2 indentation from the class & method
+					// And also reduce the insane indentation from this format style
+					.map(s -> {
+						if (s.isBlank()) { //Might have a air gap between code so don't try to substring, the beginIndex would be out of bounds
+							return "";
+						} else {
+							return s.substring(removedSpaces).replace("    ", "   ");
+						}
+					})
+					.collect(Collectors.joining("\n"));
+		}
+	}
+}

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ subprojects {
     apply plugin: 'com.github.ben-manes.versions'
     apply plugin: 'com.github.johnrengelman.shadow'
     
-    sourceCompatibility = targetCompatibility = 1.8
+    sourceCompatibility = targetCompatibility = 11
     compileJava.options.encoding = 'UTF-8'
 
     shadowJar { task ->


### PR DESCRIPTION
## Description
Add a `format` command to the bot, this also updates the language level to java 11 as the formatter used requires java 11+

The format command replies as a webhook impersonation and can be used by providing text or a message id:

**The original code message will be deleted**

### Usage 1 (Sample code)
```
|format if(Main.getServerConfig().mutedRole.containsValue(event.getGuild().getId())){
                        event.reply("Config not null");
                    } else if(event.getGuild().getRoleById(Main.getServerConfig().mutedRole.get(event.getGuild().getId())) != null){
                        event.reply("Role not null");
                    } else if(Main.getServerConfig().mutedRole.containsValue(event.getGuild().getId()) && event.getGuild().getRoleById(Main.getServerConfig().mutedRole.get(event.getGuild().getId())) != null){
                        event.reply("All good");
                    } else {
                        event.reply("All not good");
                    }
```
![image](https://user-images.githubusercontent.com/41875020/128422353-9c46a8a5-bc4d-4623-8f0c-d6119f774ae6.png)
This might not look particularly nice, but formatter can be adjusted a bit, and it would also look better if the user had some variables in place

### Usage 2
#### Step 1
![image](https://user-images.githubusercontent.com/41875020/128422411-6ba93aca-7437-4747-a753-24cf9f8b1fe6.png)
#### Step 2
![image](https://user-images.githubusercontent.com/41875020/128422527-923460d9-33d4-4934-adc8-8ba7456db048.png)
#### Step 3
**If the code author** clicks `Accept`, the embed and the old code gets removed and the message formatted, if they click `Reject`, the embed gets deleted and nothing happens